### PR TITLE
Release: Email normalization, strict validation & typo suggestions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ Simple custom auth implementation (not using full Laravel Breeze package):
 - Password hashing via bcrypt (Laravel default)
 - Session-based authentication
 
+**Email handling:** Emails are normalized (lowercase + trim) on every write and read path — `User::normalizeEmail()` plus `email`/`pending_email` model mutators, and explicit normalization in `RegistrationForm`/`ProfileForm` (before the uniqueness check) and in the `Login`/`ForgotPassword`/`ResetPassword` lookups. A backfill migration lowercased existing rows. Validation uses `email:strict` (egulias) — the bare `email`/`email:rfc` rule is lenient and accepts `a@b`/`test@localhost`; `strict` rejects those while staying Unicode-aware. `EmailSuggestionService` provides advisory "did you mean …?" domain-typo suggestions via `levenshtein()` against curated **constant** lists (static reference data, not DB — a future DB-derived version is issue #41); wired into the forms through the `SuggestsEmailCorrections` trait. Tests: `tests/Feature/EmailNormalizationTest.php`, `tests/Unit/EmailSuggestionServiceTest.php`, `tests/Feature/EmailSuggestionLivewireTest.php`.
+
 **Session & CSRF lifetime:** Session driver is `database`, `SESSION_LIFETIME` is 120 minutes, and CSRF tokens are tied to the session. A form left open past the session lifetime carries a stale token. Rather than dead-ending on Laravel's generic 419 "Page Expired" screen, `bootstrap/app.php` registers a render callback that converts the resulting `HttpException(419)` (Laravel maps `TokenMismatchException` to this before render callbacks run, so match on status 419) into a recoverable response:
 - Standard form posts (login) → redirect back with old input (minus passwords) and a `session('warning')` flash, shown automatically by the layout's toast system; the reloaded page has a fresh token
 - AJAX forms (forgot/reset password, which submit via `fetch` + `response.json()`) → JSON 419 with a `message`, surfaced as an error toast by their existing fetch handlers
@@ -327,6 +329,8 @@ This allows tracking of:
 
 **Completed:**
 - ✅ User registration and authentication with district/fleet selection
+- ✅ Email normalization (case-insensitive lowercase storage) + `email:strict` validation
+- ✅ Inline email typo suggestions ("did you mean …?") via `EmailSuggestionService`
 - ✅ Flash CRUD (create, read, update, delete)
 - ✅ Flash authorization policies
 - ✅ Date validation and duplicate prevention
@@ -544,7 +548,8 @@ The only thing not tested: flatpickr actually using the data (which is flatpickr
 - Arrange-Act-Assert pattern in all tests
 
 **Current Coverage (by area, not by count):**
-- **Auth & account** (`tests/Feature/Auth`, `tests/Feature`): login/logout/remember-me, registration + validation, password reset (throttle, token expiry, end-to-end), email verification + email-change pending pattern, resend rate limiting
+- **Auth & account** (`tests/Feature/Auth`, `tests/Feature`): login/logout/remember-me, registration + validation, password reset (throttle, token expiry, end-to-end, case-insensitive lookup), email verification + email-change pending pattern, resend rate limiting
+- **Email normalization & suggestions** (`tests/Feature/EmailNormalizationTest`, `tests/Unit/EmailSuggestionServiceTest`, `tests/Feature/EmailSuggestionLivewireTest`): lowercase storage + uniqueness, mixed-case login/reset, `email:strict`, domain-typo suggestions (incl. ccTLD false-positive guards)
 - **Logbook / flashes** (`tests/Feature`, `tests/Feature/Livewire`): create (single + multi-date), edit, delete, duplicate prevention, event-type validation, ordering, grace-period boundaries, concurrent/empty-array validation
 - **Progress & awards** (`tests/Feature`): tier calculations, non-sailing 5/yr cap, badge thresholds
 - **Leaderboards** (`tests/Feature`): sailor/fleet/district, year scoping, tie-breaking, pagination

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN mkdir -p storage/framework/sessions storage/framework/views storage/framewor
 
 # Copy application files (owned by appuser since USER is set)
 COPY public ./public
-COPY resources ./resources
+COPY resources/views ./resources/views
 COPY artisan composer.json composer.lock ./
 COPY docker/.env.docker ./.env
 

--- a/app/Http/Controllers/Auth/ForgotPassword.php
+++ b/app/Http/Controllers/Auth/ForgotPassword.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
@@ -16,8 +17,11 @@ class ForgotPassword extends Controller
     public function __invoke(Request $request): JsonResponse
     {
         $request->validate([
-            'email' => 'required|email',
+            'email' => 'required|email:strict',
         ]);
+
+        // Normalize so the lookup matches the lowercased stored email.
+        $request->merge(['email' => User::normalizeEmail($request->email)]);
 
         // Send the password reset link
         $status = Password::sendResetLink(

--- a/app/Http/Controllers/Auth/Login.php
+++ b/app/Http/Controllers/Auth/Login.php
@@ -17,8 +17,13 @@ class Login extends Controller
             'password' => 'required',
         ]);
 
+        // Normalize email so a mismatch in casing/whitespace doesn't cause a
+        // silent login failure against the lowercased stored value. Both the
+        // lookup and Auth::attempt() use the normalized credentials.
+        $credentials['email'] = User::normalizeEmail($credentials['email']);
+
         // Check if user exists
-        $user = User::where('email', $request->email)->first();
+        $user = User::where('email', $credentials['email'])->first();
 
         if (! $user) {
             // Email doesn't exist in database

--- a/app/Http/Controllers/Auth/ResetPassword.php
+++ b/app/Http/Controllers/Auth/ResetPassword.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -21,9 +22,13 @@ class ResetPassword extends Controller
     {
         $request->validate([
             'token' => 'required',
-            'email' => 'required|email',
+            'email' => 'required|email:strict',
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
+
+        // Normalize so the lookup matches the lowercased stored email (the reset
+        // link carries whatever casing was submitted to the forgot-password form).
+        $request->merge(['email' => User::normalizeEmail($request->email)]);
 
         // Attempt to reset the user's password
         $status = Password::reset(

--- a/app/Livewire/Concerns/SuggestsEmailCorrections.php
+++ b/app/Livewire/Concerns/SuggestsEmailCorrections.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Livewire\Concerns;
+
+use App\Models\User;
+use App\Services\EmailSuggestionService;
+use Livewire\Attributes\Locked;
+
+/**
+ * Adds a "did you mean ...?" email typo suggestion to a Livewire form.
+ *
+ * The host component must expose a public string $email and an 'email'
+ * validation rule. Call refreshEmailSuggestion() from updated() after the
+ * email is normalized; the view renders $emailSuggestion and wires the
+ * applyEmailSuggestion() action.
+ */
+trait SuggestsEmailCorrections
+{
+    /** The suggested correction for the current email, or null. Server-computed; #[Locked] blocks client writes. */
+    #[Locked]
+    public ?string $emailSuggestion = null;
+
+    /** Recompute the suggestion for the current email value. */
+    protected function refreshEmailSuggestion(): void
+    {
+        $this->emailSuggestion = EmailSuggestionService::suggest($this->email);
+    }
+
+    /** Accept the suggested correction and re-validate the email field. */
+    public function applyEmailSuggestion(): void
+    {
+        if ($this->emailSuggestion === null) {
+            return;
+        }
+
+        // Normalize on apply too: the service already lowercases, but this keeps
+        // the stored value consistent regardless of how the suggestion was built.
+        $this->email = User::normalizeEmail($this->emailSuggestion);
+        $this->emailSuggestion = null;
+        $this->resetErrorBag('email');
+        $this->validateOnly('email');
+    }
+}

--- a/app/Livewire/ProfileForm.php
+++ b/app/Livewire/ProfileForm.php
@@ -2,8 +2,10 @@
 
 namespace App\Livewire;
 
+use App\Livewire\Concerns\SuggestsEmailCorrections;
 use App\Models\Fleet;
 use App\Models\Member;
+use App\Models\User;
 use App\Rules\UserProfileRules;
 use App\Services\EmailVerificationService;
 use App\Services\UserDataService;
@@ -12,6 +14,8 @@ use Livewire\Component;
 
 class ProfileForm extends Component
 {
+    use SuggestsEmailCorrections;
+
     // Personal Information
     public string $first_name = '';
 
@@ -89,6 +93,13 @@ class ProfileForm extends Component
 
     public function updated($propertyName)
     {
+        // Normalize email (lowercase/trim) before live validation so the
+        // uniqueness check runs against the same value we'll store.
+        if ($propertyName === 'email') {
+            $this->email = User::normalizeEmail($this->email);
+            $this->refreshEmailSuggestion();
+        }
+
         // District/fleet are cleared programmatically (picking a district clears
         // the fleet), so don't flag them while empty — that would error an
         // untouched field. They still validate on save.
@@ -104,6 +115,11 @@ class ProfileForm extends Component
     public function save()
     {
         $user = auth()->user();
+
+        // Normalize email before validation/comparison so the uniqueness check,
+        // the email-changed comparison, and the stored value all use the
+        // lowercased/trimmed form.
+        $this->email = User::normalizeEmail($this->email);
 
         // Capture raw values to distinguish "explicit None" ('none') from auto-clear (null)
         // before normalization. JS sends 'none' for an explicit pick; null for auto-clear.

--- a/app/Livewire/RegistrationForm.php
+++ b/app/Livewire/RegistrationForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Livewire\Concerns\SuggestsEmailCorrections;
 use App\Models\District;
 use App\Models\Fleet;
 use App\Models\Member;
@@ -16,6 +17,8 @@ use Livewire\Component;
 
 class RegistrationForm extends Component
 {
+    use SuggestsEmailCorrections;
+
     // Personal Information
     public string $first_name = '';
 
@@ -93,6 +96,15 @@ class RegistrationForm extends Component
 
     public function updated($propertyName)
     {
+        // Normalize email (lowercase/trim) before live validation so the
+        // uniqueness check runs against the same value we'll store. The User
+        // model mutator also normalizes on write, but the unique rule queries
+        // the raw property, so it must be normalized here too.
+        if ($propertyName === 'email') {
+            $this->email = User::normalizeEmail($this->email);
+            $this->refreshEmailSuggestion();
+        }
+
         // 'confirmed' rule on 'password' already checks password_confirmation,
         // so validate via the 'password' field name for both. Calling
         // validateOnly('password_confirmation') would match no rule, and
@@ -130,6 +142,11 @@ class RegistrationForm extends Component
 
             return;
         }
+
+        // Normalize email before validation so the uniqueness check and the
+        // stored value both use the lowercased/trimmed form (covers pasted input
+        // that never triggered the updated() hook).
+        $this->email = User::normalizeEmail($this->email);
 
         // Validation uses rules() which includes district/fleet "explicit selection required" closures.
         // 'none' is accepted as a valid explicit choice — normalized to null after validation passes.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,11 +7,13 @@ use App\Notifications\ResetPasswordNotification;
 use Carbon\Carbon;
 use Database\Factories\UserFactory;
 use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Str;
 
 class User extends Authenticatable
 {
@@ -66,6 +68,42 @@ class User extends Authenticatable
             'date_of_birth' => 'date',
             'email_verification_expires_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Normalize an email address for storage and lookup.
+     *
+     * Lowercases and trims so that casing/whitespace differences never create
+     * duplicate accounts or silent login failures. Used by the email mutators
+     * below and by every read path (login, password reset) before lookup.
+     */
+    public static function normalizeEmail(?string $email): ?string
+    {
+        return $email === null ? null : Str::lower(trim($email));
+    }
+
+    /**
+     * Always store the primary email lowercased/trimmed.
+     *
+     * Safety net for write paths that bypass the form layer (factories,
+     * seeders, tinker). Form components normalize before validation so the
+     * uniqueness check also runs against the normalized value.
+     */
+    protected function email(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value) => self::normalizeEmail($value),
+        );
+    }
+
+    /**
+     * Always store the pending email (email-change flow) lowercased/trimmed.
+     */
+    protected function pendingEmail(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value) => self::normalizeEmail($value),
+        );
     }
 
     /**

--- a/app/Rules/UserProfileRules.php
+++ b/app/Rules/UserProfileRules.php
@@ -36,8 +36,18 @@ class UserProfileRules
             'yacht_club' => ['nullable', 'string', 'max:255'],
         ];
 
-        // Email rule (different for registration vs update)
-        $emailRule = ['required', 'string', 'email', 'max:255'];
+        // Email rule (different for registration vs update).
+        //
+        // 'email:strict' uses egulias/email-validator's NoRFCWarningsValidation
+        // (the engine Laravel already bundles). Unlike the bare 'email' rule —
+        // which maps to the lenient RFCValidation and accepts junk like "a@b" and
+        // "test@localhost" — strict rejects those plus RFC-warning addresses
+        // (trailing dots, comments, IP-literal hosts). It remains Unicode-aware,
+        // so internationalized addresses (accented local parts, IDN domains) still
+        // pass — important for the Class's international fleets. We deliberately
+        // avoid the 'dns' mode (200-500ms latency, flaky in CI); the verification
+        // email is the real liveness check.
+        $emailRule = ['required', 'string', 'email:strict', 'max:255'];
         if ($userId) {
             $emailRule[] = 'unique:users,email,'.$userId;
         } else {

--- a/app/Services/EmailSuggestionService.php
+++ b/app/Services/EmailSuggestionService.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Str;
+
+/**
+ * Suggests a corrected email address when the domain looks like a typo of a
+ * popular provider (e.g. "user@gmial.com" -> "user@gmail.com").
+ *
+ * A server-side port of the mailcheck.js approach using PHP's built-in
+ * levenshtein(): no JS dependency, no network call. It runs inside the
+ * Livewire blur round-trip that already fires for email validation, so the
+ * suggestion is essentially free. Purely advisory friction-reduction — the
+ * verification email remains the real liveness check.
+ */
+class EmailSuggestionService
+{
+    /**
+     * Popular full domains, used for whole-domain close matching.
+     *
+     * @var list<string>
+     */
+    private const DOMAINS = [
+        // Global webmail
+        'gmail.com', 'googlemail.com', 'yahoo.com', 'ymail.com', 'rocketmail.com',
+        'hotmail.com', 'outlook.com', 'live.com', 'msn.com', 'aol.com', 'aim.com',
+        'icloud.com', 'me.com', 'mac.com', 'proton.me', 'protonmail.com',
+        'gmx.com', 'mail.com', 'hey.com', 'zoho.com', 'yandex.com', 'qq.com',
+        'web.de', 'titan.email',
+        // US ISPs
+        'comcast.net', 'verizon.net', 'att.net', 'sbcglobal.net', 'cox.net',
+        'charter.net', 'earthlink.net', 'optonline.net', 'bellsouth.net',
+        // Canada / Australia / New Zealand / UK regional providers
+        'rogers.com', 'shaw.ca', 'telus.net', 'sympatico.ca', 'optusnet.com.au',
+        'xtra.co.nz', 'sky.com', 'btinternet.com', 'yahoo.co.uk', 'hotmail.co.uk',
+    ];
+
+    /**
+     * Second-level domains (the label before the TLD) we are willing to
+     * suggest. Only entries of length >= MIN_SECOND_LEVEL_LENGTH are used as
+     * correction targets, so short labels like "me"/"att" are never guessed at
+     * (which would turn "we.com" into "me.com"); exact matches still pass
+     * through untouched.
+     *
+     * @var list<string>
+     */
+    private const SECOND_LEVEL_DOMAINS = [
+        'gmail', 'googlemail', 'yahoo', 'ymail', 'rocketmail', 'hotmail',
+        'outlook', 'live', 'icloud', 'proton', 'protonmail', 'comcast',
+        'verizon', 'sbcglobal', 'charter', 'earthlink', 'optonline', 'btinternet',
+    ];
+
+    /**
+     * Top-level domains used for TLD close matching.
+     *
+     * Only entries of length >= MIN_TOP_LEVEL_LENGTH are used as correction
+     * targets (see MIN_TOP_LEVEL_LENGTH). The two-letter country codes here are
+     * therefore recognized as valid but are never *suggested* as a correction —
+     * that is what keeps a valid ".cl"/".es"/".cn" from being "fixed" to a
+     * one-edit-away neighbour like ".co"/".eu".
+     *
+     * @var list<string>
+     */
+    private const TOP_LEVEL_DOMAINS = [
+        'com', 'net', 'org', 'edu', 'gov', 'mil', 'info', 'biz', 'io',
+        'co.uk', 'com.au', 'co.nz', 'net.au',
+        // Two-letter ccTLDs: recognized as valid, never correction targets.
+        'co', 'us', 'ca', 'uk', 'de', 'fr', 'it', 'nl', 'eu', 'es', 'mx', 'ar', 'cl',
+    ];
+
+    private const DOMAIN_THRESHOLD = 2;
+
+    private const SECOND_LEVEL_THRESHOLD = 2;
+
+    private const TOP_LEVEL_THRESHOLD = 1;
+
+    private const MIN_SECOND_LEVEL_LENGTH = 5;
+
+    private const MIN_TOP_LEVEL_LENGTH = 3;
+
+    /**
+     * Suggest a corrected email, or null when the address is already fine or
+     * too far from any known domain to guess safely.
+     */
+    public static function suggest(?string $email): ?string
+    {
+        if ($email === null) {
+            return null;
+        }
+
+        $email = Str::lower(trim($email));
+
+        // Need exactly one usable @ with non-empty local and domain parts.
+        $atPos = strrpos($email, '@');
+        if ($atPos === false || $atPos === 0 || $atPos === strlen($email) - 1) {
+            return null;
+        }
+
+        $address = substr($email, 0, $atPos);
+        $domain = substr($email, $atPos + 1);
+
+        // A domain needs a dot to split into second-level + TLD ("localhost" won't).
+        if (! str_contains($domain, '.')) {
+            return null;
+        }
+
+        // Already a known-good domain — nothing to suggest.
+        if (in_array($domain, self::DOMAINS, true)) {
+            return null;
+        }
+
+        // 1) Try to correct the whole domain against popular domains.
+        // closest() only ever returns a DOMAINS member, and the input domain was
+        // already excluded above, so a non-null result is necessarily a correction.
+        $closestDomain = self::closest($domain, self::DOMAINS, self::DOMAIN_THRESHOLD);
+        if ($closestDomain !== null) {
+            return $address.'@'.$closestDomain;
+        }
+
+        // 2) Otherwise correct the second-level and top-level parts separately,
+        //    which catches compound typos like "gmial.con".
+        // Split on the FIRST dot: for compound TLDs like "co.uk" the full
+        // remainder matches a TOP_LEVEL_DOMAINS entry directly. For deeper
+        // hostnames the parts won't match any list and we fall through to no
+        // suggestion — the intended safe behavior.
+        $dotPos = strpos($domain, '.');
+        $secondLevel = substr($domain, 0, $dotPos);
+        $topLevel = substr($domain, $dotPos + 1);
+
+        $closestSecondLevel = self::closest(
+            $secondLevel,
+            self::SECOND_LEVEL_DOMAINS,
+            self::SECOND_LEVEL_THRESHOLD,
+            self::MIN_SECOND_LEVEL_LENGTH
+        );
+        $closestTopLevel = self::closest($topLevel, self::TOP_LEVEL_DOMAINS, self::TOP_LEVEL_THRESHOLD, self::MIN_TOP_LEVEL_LENGTH);
+
+        $suggestedDomain = ($closestSecondLevel ?? $secondLevel).'.'.($closestTopLevel ?? $topLevel);
+
+        if ($suggestedDomain !== $domain) {
+            return $address.'@'.$suggestedDomain;
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the closest candidate to $input within $threshold edits, or null.
+     * An exact match returns null (nothing to correct). Candidates shorter than
+     * $minCandidateLength are ignored as targets.
+     *
+     * Candidates must share $input's first character. Real-world typos almost
+     * never alter the leading character, and this guard prevents short distinct
+     * domains from colliding (e.g. "we.com" being "corrected" to "me.com").
+     *
+     * @param  list<string>  $candidates
+     */
+    private static function closest(string $input, array $candidates, int $threshold, int $minCandidateLength = 0): ?string
+    {
+        if ($input === '' || in_array($input, $candidates, true)) {
+            return null;
+        }
+
+        $best = null;
+        $bestDistance = PHP_INT_MAX;
+
+        foreach ($candidates as $candidate) {
+            // Byte-index first-char comparison is intentional: candidates (and
+            // typical email domains) are ASCII. A multibyte input simply won't
+            // match any ASCII candidate's first byte, yielding no suggestion.
+            if (strlen($candidate) < $minCandidateLength || $candidate[0] !== $input[0]) {
+                continue;
+            }
+
+            $distance = levenshtein($input, $candidate);
+            if ($distance < $bestDistance) {
+                $bestDistance = $distance;
+                $best = $candidate;
+            }
+        }
+
+        return $bestDistance <= $threshold ? $best : null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
             "APP_ENV=testing php artisan test"
         ],
         "check": [
-            "@php -r \"if(shell_exec('lsof -ti:8000')) { echo 'ERROR: Dev server is running on port 8000'; exit(1); }\"",
             "APP_ENV=testing php artisan config:clear --ansi",
             "vendor/bin/pint --test",
             "vendor/bin/phpstan analyze --memory-limit=512M",

--- a/database/migrations/2026_06_05_124258_backfill_lowercase_emails.php
+++ b/database/migrations/2026_06_05_124258_backfill_lowercase_emails.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Lowercase any existing mixed-case emails so they match the values the
+     * application now writes (User::normalizeEmail + email mutators). Runs
+     * before the stricter validation/normalization is relied upon for lookups.
+     *
+     * Irreversible: the original casing isn't recorded, so there's no down().
+     */
+    public function up(): void
+    {
+        DB::table('users')
+            ->whereRaw('email <> LOWER(email)')
+            ->update(['email' => DB::raw('LOWER(email)')]);
+
+        DB::table('users')
+            ->whereNotNull('pending_email')
+            ->whereRaw('pending_email <> LOWER(pending_email)')
+            ->update(['pending_email' => DB::raw('LOWER(pending_email)')]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * No-op: lowercasing is not reversible (original casing was not preserved).
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -37,6 +37,10 @@ District and fleet affiliations are tracked per calendar year. When users regist
 
 **Note**: Users don't need to own a Lightning - crews and anyone who sails on Lightnings can participate.
 
+**Email Handling:**
+- Email addresses are case-insensitive — stored in lowercase, so casing or whitespace differences can't create duplicate accounts, and sign-in works regardless of how the address is typed.
+- Inline typo detection: when the email's domain looks like a misspelling of a common provider (e.g. `gmial.com`), the form shows an advisory "Did you mean …?" suggestion that the user can click to apply. It never blocks submission — the verification email remains the authoritative check.
+
 **Email Verification:**
 - New users receive a verification email upon registration with a 24-hour token expiration
 - Users can immediately access and use all application features without verifying their email (soft verification)
@@ -81,6 +85,7 @@ Users can view and edit their profile information through a dedicated profile pa
   - Users can resend verification or cancel the email change
   - Upon verification, pending email becomes the active email
 - Email changes require re-verification even if original email was verified
+- The same case-insensitive handling and "Did you mean …?" typo suggestion apply when changing email (see Section 1.1)
 
 ### 1.4 Data Export
 Users can export their complete profile and activity history:

--- a/resources/views/components/user-profile-fields.blade.php
+++ b/resources/views/components/user-profile-fields.blade.php
@@ -1,4 +1,4 @@
-@props(['districtSelectId' => 'district-select', 'fleetSelectId' => 'fleet-select'])
+@props(['districtSelectId' => 'district-select', 'fleetSelectId' => 'fleet-select', 'emailSuggestion' => null])
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-x-4">
     <!-- First Name -->
@@ -45,6 +45,16 @@
             <span class="label-text-alt text-error">{{ $message }}</span>
         </div>
     @enderror
+    @if ($emailSuggestion)
+        <div class="label" wire:key="email-suggestion">
+            <span class="label-text-alt">
+                Did you mean
+                <button type="button"
+                        wire:click="applyEmailSuggestion"
+                        class="link link-primary font-semibold">{{ $emailSuggestion }}</button>?
+            </span>
+        </div>
+    @endif
 </div>
 
 {{ $passwordFields ?? '' }}

--- a/resources/views/livewire/profile-form.blade.php
+++ b/resources/views/livewire/profile-form.blade.php
@@ -3,7 +3,7 @@
         <h1 class="text-3xl font-bold text-center mb-6">Edit Profile</h1>
 
         <form wire:submit="save" novalidate>
-            <x-user-profile-fields>
+            <x-user-profile-fields :email-suggestion="$emailSuggestion">
                 <x-slot:passwordFields>
                     @if($hasPendingEmail)
                         <!-- Pending Email Change Notice -->

--- a/resources/views/livewire/registration-form.blade.php
+++ b/resources/views/livewire/registration-form.blade.php
@@ -3,7 +3,7 @@
         <h1 class="text-3xl font-bold text-center mb-6">Create Account</h1>
 
         <form wire:submit="register" novalidate>
-            <x-user-profile-fields>
+            <x-user-profile-fields :email-suggestion="$emailSuggestion">
                 <x-slot:passwordFields>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-x-4">
                         <!-- Password -->

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -336,4 +336,49 @@ class PasswordResetTest extends TestCase
         $response->assertRedirect(route('logbook.index'));
         $this->assertAuthenticatedAs($user);
     }
+
+    public function test_reset_link_request_normalizes_mixed_case_email(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'sailor@example.com']);
+
+        // Request with different casing than the stored (lowercased) email.
+        $response = $this->post(route('password.email'), [
+            'email' => 'Sailor@Example.COM',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['success' => true]);
+        Notification::assertSentTo($user, ResetPasswordNotification::class);
+    }
+
+    public function test_reset_link_request_rejects_malformed_email(): void
+    {
+        // Consistency with registration: forgot-password uses email:strict, so a
+        // junk address that the lenient rule would accept is rejected up front.
+        $response = $this->postJson(route('password.email'), [
+            'email' => 'a@b',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_password_can_be_reset_with_mixed_case_email(): void
+    {
+        $user = User::factory()->create(['email' => 'sailor@example.com']);
+        $token = Password::broker()->createToken($user);
+
+        $response = $this->post(route('password.update'), [
+            'token' => $token,
+            'email' => 'Sailor@Example.COM',
+            'password' => 'new-password123',
+            'password_confirmation' => 'new-password123',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['success' => true]);
+        $this->assertTrue(Hash::check('new-password123', $user->fresh()->password));
+    }
 }

--- a/tests/Feature/EmailNormalizationTest.php
+++ b/tests/Feature/EmailNormalizationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\ProfileForm;
+use App\Livewire\RegistrationForm;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class EmailNormalizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Register through the Livewire form with a mixed-case/whitespace email and
+     * the given event call, returning the test instance.
+     *
+     * @param  array<string, mixed>  $overrides
+     */
+    private function registerWith(string $email, array $overrides = []): Testable
+    {
+        $data = array_merge([
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'email' => $email,
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'date_of_birth' => '1990-01-01',
+            'gender' => 'male',
+            'address_line1' => '123 Main St',
+            'city' => 'Anytown',
+            'state' => 'CA',
+            'zip_code' => '12345',
+            'country' => 'USA',
+            'district_id' => 'none',
+            'fleet_id' => 'none',
+            'yacht_club' => '',
+        ], $overrides);
+
+        $component = Livewire::test(RegistrationForm::class);
+        foreach ($data as $key => $value) {
+            $component->set($key, $value);
+        }
+
+        return $component->call('register');
+    }
+
+    public function test_registration_stores_email_lowercased_and_trimmed(): void
+    {
+        $this->registerWith('  John.Doe@Example.COM ')
+            ->assertRedirect(route('logbook.index'));
+
+        $this->assertAuthenticated();
+        $this->assertDatabaseHas('users', ['email' => 'john.doe@example.com']);
+        $this->assertDatabaseMissing('users', ['email' => 'John.Doe@Example.COM']);
+    }
+
+    public function test_reregistering_with_different_case_fails_uniqueness(): void
+    {
+        User::factory()->create(['email' => 'test@example.com']);
+
+        $this->registerWith('TEST@example.com')
+            ->assertHasErrors('email');
+
+        // No second account was created.
+        $this->assertEquals(1, User::where('email', 'test@example.com')->count());
+    }
+
+    public function test_login_matches_mixed_case_against_lowercased_stored_value(): void
+    {
+        User::factory()->create([
+            'email' => 'test@example.com',
+            'password' => bcrypt('password123'),
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => 'Test@Example.COM',
+            'password' => 'password123',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(route('logbook.index'));
+    }
+
+    public function test_validation_rejects_rfc_warning_addresses(): void
+    {
+        // "a@b" and "test@localhost" pass the lenient default 'email' rule but
+        // are rejected by 'email:strict'.
+        $this->registerWith('a@b')->assertHasErrors('email');
+        $this->registerWith('test@localhost')->assertHasErrors('email');
+    }
+
+    public function test_validation_still_accepts_internationalized_addresses(): void
+    {
+        // email:strict is Unicode-aware: accented local parts / IDN domains pass.
+        $this->registerWith('üser@münchen.de')
+            ->assertHasNoErrors('email')
+            ->assertRedirect(route('logbook.index'));
+    }
+
+    public function test_user_model_lowercases_email_on_direct_write(): void
+    {
+        // Mutator safety net for paths that bypass the form layer (factories,
+        // seeders, tinker).
+        $user = User::factory()->create(['email' => 'Mixed@Case.COM']);
+
+        $this->assertSame('mixed@case.com', $user->fresh()->email);
+    }
+
+    public function test_profile_email_change_stores_pending_email_lowercased(): void
+    {
+        $user = User::factory()->create(['email' => 'current@example.com']);
+        $this->actingAs($user);
+
+        Livewire::test(ProfileForm::class)
+            ->set('email', 'NewAddress@Example.COM')
+            ->call('save')
+            ->assertHasNoErrors('email');
+
+        // Primary email unchanged until verified; pending_email is normalized.
+        $this->assertSame('current@example.com', $user->fresh()->email);
+        $this->assertSame('newaddress@example.com', $user->fresh()->pending_email);
+    }
+}

--- a/tests/Feature/EmailSuggestionLivewireTest.php
+++ b/tests/Feature/EmailSuggestionLivewireTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\ProfileForm;
+use App\Livewire\RegistrationForm;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class EmailSuggestionLivewireTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registration_form_surfaces_a_suggestion_for_a_typo(): void
+    {
+        Livewire::test(RegistrationForm::class)
+            ->set('email', 'sailor@gmial.com')
+            ->assertSet('emailSuggestion', 'sailor@gmail.com')
+            // The suggestion is rendered (prop reaches the shared blade component).
+            ->assertSee('Did you mean')
+            ->assertSee('sailor@gmail.com');
+    }
+
+    public function test_registration_form_clears_suggestion_for_a_good_address(): void
+    {
+        Livewire::test(RegistrationForm::class)
+            ->set('email', 'sailor@gmial.com')
+            ->assertSet('emailSuggestion', 'sailor@gmail.com')
+            ->set('email', 'sailor@gmail.com')
+            ->assertSet('emailSuggestion', null);
+    }
+
+    public function test_applying_the_suggestion_corrects_the_email_field(): void
+    {
+        Livewire::test(RegistrationForm::class)
+            ->set('email', 'sailor@gmial.com')
+            ->call('applyEmailSuggestion')
+            ->assertSet('email', 'sailor@gmail.com')
+            ->assertSet('emailSuggestion', null)
+            ->assertHasNoErrors('email');
+    }
+
+    public function test_applying_with_no_suggestion_is_a_noop(): void
+    {
+        Livewire::test(RegistrationForm::class)
+            ->set('email', 'sailor@gmail.com')
+            ->assertSet('emailSuggestion', null)
+            ->call('applyEmailSuggestion')
+            ->assertSet('email', 'sailor@gmail.com')
+            ->assertSet('emailSuggestion', null);
+    }
+
+    public function test_profile_form_surfaces_a_suggestion_for_a_typo(): void
+    {
+        $user = User::factory()->create(['email' => 'current@example.com']);
+
+        Livewire::actingAs($user)
+            ->test(ProfileForm::class)
+            ->set('email', 'current@yahooo.com')
+            ->assertSet('emailSuggestion', 'current@yahoo.com')
+            ->call('applyEmailSuggestion')
+            ->assertSet('email', 'current@yahoo.com')
+            ->assertSet('emailSuggestion', null);
+    }
+}

--- a/tests/Unit/EmailSuggestionServiceTest.php
+++ b/tests/Unit/EmailSuggestionServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\EmailSuggestionService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class EmailSuggestionServiceTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function typoProvider(): array
+    {
+        return [
+            'second-level typo' => ['john@gmial.com', 'john@gmail.com'],
+            'doubled letter' => ['jane@yahooo.com', 'jane@yahoo.com'],
+            'tld typo (con)' => ['kim@gmail.con', 'kim@gmail.com'],
+            'compound typo (both parts)' => ['amy@gmial.con', 'amy@gmail.com'],
+            'hotmail misspelling' => ['bob@hotmial.com', 'bob@hotmail.com'],
+            'outlook misspelling' => ['sue@outlok.com', 'sue@outlook.com'],
+            'comcast misspelling' => ['ed@comcsat.net', 'ed@comcast.net'],
+            'preserves local part with dots' => ['john.s.doe@gmial.com', 'john.s.doe@gmail.com'],
+            // International / regional providers added in the targeted merge.
+            'yandex typo' => ['ivan@yandx.com', 'ivan@yandex.com'],
+            // Caught by the whole-domain pass (1 edit from "web.de"), NOT the
+            // second-level split — "web" is below MIN_SECOND_LEVEL_LENGTH (5).
+            'web.de tld typo' => ['hans@web.ed', 'hans@web.de'],
+            'qq compound typo' => ['li@qq.con', 'li@qq.com'],
+            'rogers (CA) typo' => ['amy@rogers.con', 'amy@rogers.com'],
+        ];
+    }
+
+    #[DataProvider('typoProvider')]
+    public function test_suggests_correction_for_typos(string $input, string $expected): void
+    {
+        $this->assertSame($expected, EmailSuggestionService::suggest($input));
+    }
+
+    /**
+     * @return array<string, array{0: ?string}>
+     */
+    public static function noSuggestionProvider(): array
+    {
+        return [
+            'correct gmail' => ['real@gmail.com'],
+            'correct outlook' => ['user@outlook.com'],
+            'correct co.uk' => ['user@yahoo.co.uk'],
+            'unknown but plausible domain' => ['staff@mycompany.com'],
+            'unknown org' => ['info@lightningclass.org'],
+            // ccTLD safety: a valid two-letter country code must never be
+            // "corrected" toward a one-edit-away neighbour (.cl->.co, .es->.eu).
+            'spanish ccTLD .es' => ['socio@empresa.es'],
+            'chilean ccTLD .cl' => ['vela@club.cl'],
+            'mexican ccTLD .mx' => ['regata@club.mx'],
+            'unlisted ccTLD .cn not corrected to .co' => ['user@site.cn'],
+            'unlisted ccTLD .ec not corrected to .eu' => ['user@vela.ec'],
+            'no domain part' => ['justtext'],
+            'empty domain' => ['user@'],
+            'empty local part' => ['@gmail.com'],
+            'dotless domain' => ['user@localhost'],
+            'null' => [null],
+            'empty string' => [''],
+        ];
+    }
+
+    #[DataProvider('noSuggestionProvider')]
+    public function test_returns_null_when_no_safe_suggestion(?string $input): void
+    {
+        $this->assertNull(EmailSuggestionService::suggest($input));
+    }
+
+    public function test_does_not_guess_at_short_second_level_labels(): void
+    {
+        // "we" is one edit from the listed "me", but short labels are never used
+        // as correction targets, so we must not turn "we.com" into "me.com".
+        $this->assertNull(EmailSuggestionService::suggest('user@we.com'));
+    }
+
+    public function test_normalizes_case_before_suggesting(): void
+    {
+        $this->assertSame('john@gmail.com', EmailSuggestionService::suggest('John@GMIAL.COM'));
+    }
+}


### PR DESCRIPTION
Promotes #42 from `develop` to `main`.

### Added
- Inline email typo suggestions ("did you mean gmail.com?") — advisory, click-to-apply, never blocks submission (`EmailSuggestionService`, zero new dependencies).
- Case-insensitive email handling end-to-end (registration, login, profile, password reset).

### Changed
- Email validation tightened to `email:strict` (egulias) — rejects junk like `a@b`/`test@localhost` while staying Unicode-aware.
- Emails are stored lowercased + trimmed; `pending_email` likewise.

### Fixed
- Casing/whitespace differences can no longer create duplicate accounts or cause silent login / password-reset failures.

### Technical
- `User::normalizeEmail()` + `email`/`pending_email` model mutators; explicit normalization on auth read paths.
- One-way backfill migration lowercases existing rows.
- `SuggestsEmailCorrections` Livewire trait; `#[Locked]` on the server-computed suggestion property.
- Dropped the obsolete port-8000 guard from `composer check`; slimmed the Docker runtime image to copy only `resources/views`.
- New tests: `EmailNormalizationTest`, `EmailSuggestionServiceTest`, `EmailSuggestionLivewireTest`, plus mixed-case password-reset coverage. Full `composer check` green.
- Follow-up idea (self-learning suggestion list from verified domains) tracked in #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)