### PR TITLE
Real client IP, auth rate-limiting & env hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ ASSET_URL=/
 # Staging / dev (e.g. dev.gotflashes.com): set APP_ENV=staging, APP_DEBUG=false, a NEW APP_KEY,
 # a SEPARATE DB_DATABASE, MAIL_MAILER=log, and BASIC_AUTH_* credentials. APP_ENV=staging engages
 # the noindex header + basic-auth gate + non-production mail allowlist automatically.
-# Full delta: docs/real-ip-and-rate-limiting.md ("dev environment variables").
+# Full delta: DOCKER.md ("Staging / dev environment").
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ APP_DEBUG=true
 APP_URL=https://gotflashes.com
 ASSET_URL=/
 
+# Staging / dev (e.g. dev.gotflashes.com): set APP_ENV=staging, APP_DEBUG=false, a NEW APP_KEY,
+# a SEPARATE DB_DATABASE, MAIL_MAILER=log, and BASIC_AUTH_* credentials. APP_ENV=staging engages
+# the noindex header + basic-auth gate + non-production mail allowlist automatically.
+# Full delta: docs/real-ip-and-rate-limiting.md ("dev environment variables").
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
@@ -64,8 +69,8 @@ MAIL_ALLOWLIST_ENABLED=
 # Comma-separated; matched exactly — subdomains (mail.resend.dev) are NOT included.
 MAIL_ALLOWED_DOMAINS=resend.dev
 
-# HTTP Basic Authentication (for production environment protection)
-# Leave empty to disable. Used to protect staging/preview environments.
+# HTTP Basic Authentication (protects every deployed environment: production + staging/dev).
+# Applies in all environments except local/testing; leave empty to disable.
 # Note: These are plain text passwords, not hashed like user passwords.
 BASIC_AUTH_USERNAME=
 BASIC_AUTH_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ test-results/
 playwright-report/
 tests/Browser/Screenshots/
 .claude/worktrees/
+
+# Local investigation notes (not tracked)
+/notes/

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ tests/Browser/Screenshots/
 
 # Local investigation notes (not tracked)
 /notes/
+
+# Windows "Mark of the Web" alternate-data-stream artifacts (appear on WSL when
+# files are copied/downloaded via Windows, e.g. nginx-access.log:Zone.Identifier)
+*:Zone.Identifier

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,9 @@ Routes in `routes/web.php`:
 
 The application includes comprehensive observability features via `ObservabilityServiceProvider` and middleware:
 
+### Proxy & Real Client IP (load-bearing for logging)
+Real client IPs in the request/`security` logs below — and Laravel rate-limiting — come from **nginx's realip module keyed on `CF-Connecting-IP`** (`docker/nginx.conf`), which rewrites `REMOTE_ADDR` to the true client before PHP sees it; `$request->ip()` reads that. Request chain in production: **Cloudflare → HAProxy (on pfSense) → nginx → app**. `set_real_ip_from 0.0.0.0/0` is safe *only* because a pfSense firewall rule restricts ingress to Cloudflare IPs, so every request has already passed through Cloudflare (which sets `CF-Connecting-IP` to the true client and is not client-spoofable, unlike the leftmost `X-Forwarded-For`). The firewall rule is the enforcement — if it were removed, `CF-Connecting-IP` would become forgeable. `trustProxies(at: env('TRUSTED_PROXY_IP'))` in `bootstrap/app.php` is **inert** (defense-in-depth only): nginx has already resolved the client IP, so it never matches a proxy peer and does not affect `$request->ip()`. Do not point IP logging or rate-limiting logic at `trustProxies`/`TRUSTED_PROXY_IP`.
+
 ### Request Logging (`RequestLoggingMiddleware`)
 - **All HTTP requests** are logged with structured context:
   - Unique request ID (UUID) for tracing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,14 @@ The application includes comprehensive observability features via `Observability
 ### Proxy & Real Client IP (load-bearing for logging)
 Real client IPs in the request/`security` logs below — and Laravel rate-limiting — come from **nginx's realip module keyed on `CF-Connecting-IP`** (`docker/nginx.conf`), which rewrites `REMOTE_ADDR` to the true client before PHP sees it; `$request->ip()` reads that. Request chain in production: **Cloudflare → HAProxy (on pfSense) → nginx → app**. `set_real_ip_from 0.0.0.0/0` is safe *only* because a pfSense firewall rule restricts ingress to Cloudflare IPs, so every request has already passed through Cloudflare (which sets `CF-Connecting-IP` to the true client and is not client-spoofable, unlike the leftmost `X-Forwarded-For`). The firewall rule is the enforcement — if it were removed, `CF-Connecting-IP` would become forgeable. `trustProxies(at: env('TRUSTED_PROXY_IP'))` in `bootstrap/app.php` is **inert** (defense-in-depth only): nginx has already resolved the client IP, so it never matches a proxy peer and does not affect `$request->ip()`. Do not point IP logging or rate-limiting logic at `trustProxies`/`TRUSTED_PROXY_IP`.
 
+### Auth Rate Limiting
+Auth endpoints throttle on the real client IP above, via `App\Support\IpRateLimiter` (which hashes any user-supplied key component so entity/accent variants like `josé@x.com`/`jose@x.com` can't collide buckets). Throttle hits are logged to the `security` channel through `App\Support\SecurityLog`:
+- **Login** (`Login.php`) — 5 failures/min per email+IP **plus** a coarse 25/15-min per-IP backstop. Counts failures only, cleared on success. Keyed on email+IP (never IP alone) so a shared club/family NAT can't lock out unrelated members; the lockout retry time is computed from only the limiter(s) that actually tripped.
+- **Password reset request** (`/password/email`, `ForgotPassword.php`) — 5/hour/IP, counted **only when mail is actually sent** (so broker-throttled/invalid requests don't drain a shared IP's budget), on top of Laravel's per-email 60s broker throttle.
+- **Password reset submit** (`/password/reset`, `ResetPassword.php`) — 10/hour/IP (token-guessing defense-in-depth; every submission counts).
+- **Registration / verification resend** — pre-existing per-IP/per-user caps (`RegistrationForm`, `EmailVerificationService`).
+- **Warn-only mail-volume monitor** (`ObservabilityServiceProvider`) — logs to `security` at ~80/day (Resend free cap = 100/day). Alerts on a distributed drain the per-IP/per-email caps can't catch; deliberately never blocks (a blocking cap would drop legitimate mail).
+
 ### Request Logging (`RequestLoggingMiddleware`)
 - **All HTTP requests** are logged with structured context:
   - Unique request ID (UUID) for tracing

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -8,7 +8,7 @@ Most environment variables are pre-configured in `docker/.env.docker`. You only 
 
 **Required:**
 - `APP_KEY` - Generate with: `docker run --rm php:8.2-cli php -r "echo 'base64:' . base64_encode(random_bytes(32)) . PHP_EOL;"`
-- `TRUSTED_PROXY_IP` - IP of reverse proxy (e.g., HAProxy) to trust X-Forwarded-* headers for correct client IP and HTTPS detection
+- `TRUSTED_PROXY_IP` - Reverse-proxy (HAProxy) IP. Currently **inert defense-in-depth**: nginx resolves the real client IP from Cloudflare's `CF-Connecting-IP` header (`docker/nginx.conf`) and rewrites `REMOTE_ADDR` before PHP sees it, so `$request->ip()` does not depend on this and HTTPS is owned by `forceScheme`/`APP_URL`. Set it for config consistency; do not point IP logging or rate-limiting logic at it. See CLAUDE.md → "Proxy & Real Client IP".
 - `RESEND_KEY` - API key for [Resend](https://resend.com) email service. Required for email verification and notifications. Get your key from the Resend dashboard.
 
 **Optional:**
@@ -17,6 +17,38 @@ Most environment variables are pre-configured in `docker/.env.docker`. You only 
 - `START_YEAR` - Controls grace period logic for logging previous year entries (default: `2026`). The January grace period (allowing previous year entries) only applies when current year > START_YEAR. Example: With `START_YEAR=2026`, January 2026 allows only 2026 entries, but January 2027+ allows December 2026 entries.
 
 The container runs on port 8080 (HTTP only). Put a reverse proxy in front for SSL termination.
+
+## Staging / dev environment (e.g. dev.gotflashes.com)
+
+Run non-production clones as **`APP_ENV=staging`** (not `production`). That single value engages the
+privacy protections and the non-production mail allowlist, and keeps `APP_DEBUG` distinct from prod.
+Same `Cloudflare → HAProxy → container` request path as production.
+
+**Privacy — two independent layers, both keyed off `APP_ENV != production`:**
+- `PreventIndexingNonProduction` adds `X-Robots-Tag: noindex, nofollow, noarchive` to every response —
+  the actual no-index *guarantee* (prevents indexing, not just crawling; works for non-HTML responses;
+  holds even if basic-auth credentials are blank).
+- `BasicAuthMiddleware` gates all envs except `local`/`testing` when `BASIC_AUTH_*` are set (401 to
+  crawlers and casual visitors). `/up` stays exempt for HAProxy health checks.
+
+**Environment variable deltas from prod:**
+
+| Var | Dev value | Why |
+| --- | --- | --- |
+| `APP_ENV` | `staging` | Engages noindex + basic-auth gate + mail allowlist; distinct from prod. |
+| `APP_KEY` | new (`php artisan key:generate`) | Separate session/encryption integrity — don't reuse prod's. |
+| `APP_URL` | `https://dev.gotflashes.com` | Drives forceScheme, generated URLs, reset/verify links, sitemap base. |
+| `APP_DEBUG` | `false` | Public/CF-reachable; `true` leaks stack traces even behind basic auth. |
+| `DB_DATABASE` | separate file/volume | **Never point dev at prod's DB.** |
+| `MAIL_MAILER` | `log` (safest) or `resend` with a **separate** `RESEND_KEY` | Don't burn prod's quota or send real mail from dev. |
+| `BASIC_AUTH_USERNAME` / `BASIC_AUTH_PASSWORD` | non-empty | The access gate. Blank = no gate (noindex still applies). |
+| `APP_NAME` | `"G.O.T. Flashes (Staging)"` (optional) | Distinguishes UI/email subjects from prod. |
+
+**Keep the same as prod:** `SESSION_SECURE_COOKIE=true` (dev is HTTPS via HAProxy),
+`CACHE_STORE=database`, `TRUSTED_PROXY_IP` (inert but consistent), locale, `START_YEAR`, `BCRYPT_ROUNDS`.
+
+The two critical isolation points are a **separate `DB_DATABASE`** and **separate mail** (`log` or a
+distinct Resend key) — everything else is keyed off `APP_ENV`.
 
 ## Container Startup
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Logs are written to `storage/logs/`. During development, view real-time logs wit
 - **HAProxy**: SSL termination and reverse proxy
 - **Docker Container**: Application (nginx + PHP-FPM + Supervisor)
 
-**Security Note:** Firewall-level restrictions ensure only Cloudflare IPs can reach the server, allowing nginx to safely trust `X-Forwarded-For` headers for real client IP logging.
+**Security Note:** Firewall-level restrictions ensure only Cloudflare IPs can reach the server, so nginx's realip module can safely resolve the real client IP from the `CF-Connecting-IP` header (set by Cloudflare, not client-spoofable) for logging and rate-limiting. Laravel's `trustProxies` (`TRUSTED_PROXY_IP`) is inert defense-in-depth — nginx already rewrites `REMOTE_ADDR`, so `$request->ip()` does not depend on it.
 
 See this [guide](https://johnhringiv.com/secure-scalable-home-web-hosting) for the full deployment setup.
 

--- a/app/Console/Commands/PruneExpiredCache.php
+++ b/app/Console/Commands/PruneExpiredCache.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class PruneExpiredCache extends Command
+{
+    protected $signature = 'cache:prune-expired';
+
+    protected $description = 'Delete expired rows from the database cache store (they are otherwise only evicted lazily on re-read, so short-lived rate-limiter keys accumulate forever).';
+
+    public function handle(): int
+    {
+        if (config('cache.default') !== 'database') {
+            $this->info('Cache store is not "database"; nothing to prune.');
+
+            return self::SUCCESS;
+        }
+
+        $deleted = DB::connection(config('cache.stores.database.connection'))
+            ->table(config('cache.stores.database.table', 'cache'))
+            ->where('expiration', '<', now()->getTimestamp())
+            ->delete();
+
+        $this->info("Pruned {$deleted} expired cache row(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Auth/Concerns/ThrottlesByIp.php
+++ b/app/Http/Controllers/Auth/Concerns/ThrottlesByIp.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Auth\Concerns;
+
+use App\Support\IpRateLimiter;
+use App\Support\SecurityLog;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Shared per-IP throttle for the AJAX auth controllers (forgot / reset password),
+ * which both answer with a JSON 429 and a security-log entry. Returns the 429
+ * response when the IP is over its cap, or null to let the request proceed.
+ */
+trait ThrottlesByIp
+{
+    protected function throttledJsonResponse(
+        string $key,
+        int $maxAttempts,
+        string $event,
+        string $logMessage,
+        string $userMessage
+    ): ?JsonResponse {
+        if (! IpRateLimiter::tooManyAttempts($key, $maxAttempts)) {
+            return null;
+        }
+
+        SecurityLog::warning($event, $logMessage, [
+            'email' => request()->input('email'),
+            'retry_after' => IpRateLimiter::availableIn($key),
+        ]);
+
+        return response()->json([
+            'success' => false,
+            'message' => $userMessage,
+        ], 429);
+    }
+}

--- a/app/Http/Controllers/Auth/ForgotPassword.php
+++ b/app/Http/Controllers/Auth/ForgotPassword.php
@@ -2,24 +2,27 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Http\Controllers\Auth\Concerns\ThrottlesByIp;
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Support\IpRateLimiter;
+use App\Support\SecurityLog;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Validation\ValidationException;
 
 class ForgotPassword extends Controller
 {
+    use ThrottlesByIp;
+
     /**
-     * Per-IP cap on reset-link requests, on top of the per-email broker throttle
+     * Per-IP cap on reset emails, on top of the per-email broker throttle
      * (config/auth.php 'throttle' => 60). The broker throttle is per-email, so it
      * does nothing against one source requesting resets across many accounts —
-     * mail-bombing / enumeration / single-IP quota drain. This closes that gap.
-     * Resets are rare for real users, so 5/hour is generous even on a shared
-     * club/family IP. Distributed drains are surfaced by the warn-only mail monitor.
+     * mail-bombing / quota drain. This closes that gap. Resets are rare for real
+     * users, so 5/hour is generous even on a shared club/family IP. Distributed
+     * drains are surfaced by the warn-only mail monitor.
      */
     private const MAX_PER_IP = 5;
 
@@ -37,25 +40,17 @@ class ForgotPassword extends Controller
         // Normalize so the lookup matches the lowercased stored email.
         $request->merge(['email' => User::normalizeEmail($request->email)]);
 
-        // Per-IP throttle — counts every request (valid or not) so enumeration sweeps
-        // and mail-bombing from one source are capped, each of which would send an email.
-        $ipKey = 'password-email:'.$request->ip();
-        if (RateLimiter::tooManyAttempts($ipKey, self::MAX_PER_IP)) {
-            Log::channel('security')->warning('Password reset request throttled', [
-                'event' => 'password_reset_throttled',
-                'email' => $request->email,
-                'ip' => $request->ip(),
-                'retry_after' => RateLimiter::availableIn($ipKey),
-                'user_agent' => $request->userAgent(),
-                'timestamp' => now()->toIso8601String(),
-            ]);
-
-            return response()->json([
-                'success' => false,
-                'message' => 'Too many reset requests. Please wait a while and try again.',
-            ], 429);
+        // Per-IP throttle — gate before doing any work.
+        $ipKey = IpRateLimiter::ipKey('password-email', $request->ip());
+        if ($throttled = $this->throttledJsonResponse(
+            $ipKey,
+            self::MAX_PER_IP,
+            'password_reset_throttled',
+            'Password reset request throttled',
+            'Too many reset requests. Please wait a while and try again.'
+        )) {
+            return $throttled;
         }
-        RateLimiter::hit($ipKey, self::DECAY_PER_IP);
 
         // Send the password reset link
         $status = Password::sendResetLink(
@@ -64,12 +59,14 @@ class ForgotPassword extends Controller
 
         // Check if the password reset link was sent successfully
         if ($status === Password::RESET_LINK_SENT) {
-            Log::channel('security')->info('Password reset link sent', [
-                'event' => 'password_reset_requested',
+            // Only count requests that actually dispatched mail, so broker-throttled
+            // retries and invalid-email probes don't drain the shared-IP budget for
+            // legitimate users behind the same NAT. This keeps the cap tracking
+            // "emails this IP caused", matching its mail-bomb / quota-drain intent.
+            IpRateLimiter::hit($ipKey, self::DECAY_PER_IP);
+
+            SecurityLog::info('password_reset_requested', 'Password reset link sent', [
                 'email' => $request->email,
-                'ip' => $request->ip(),
-                'user_agent' => $request->userAgent(),
-                'timestamp' => now()->toIso8601String(),
             ]);
 
             return response()->json([
@@ -80,11 +77,8 @@ class ForgotPassword extends Controller
 
         // Handle the per-email broker throttle (separate from the per-IP cap above)
         if ($status === Password::RESET_THROTTLED) {
-            Log::channel('security')->info('Password reset broker-throttled', [
-                'event' => 'password_reset_broker_throttled',
+            SecurityLog::info('password_reset_broker_throttled', 'Password reset broker-throttled', [
                 'email' => $request->email,
-                'ip' => $request->ip(),
-                'timestamp' => now()->toIso8601String(),
             ]);
 
             return response()->json([
@@ -94,12 +88,8 @@ class ForgotPassword extends Controller
         }
 
         // Invalid user (no matching account) — logged to surface enumeration sweeps.
-        Log::channel('security')->info('Password reset requested for unknown email', [
-            'event' => 'password_reset_invalid_user',
+        SecurityLog::info('password_reset_invalid_user', 'Password reset requested for unknown email', [
             'email' => $request->email,
-            'ip' => $request->ip(),
-            'user_agent' => $request->userAgent(),
-            'timestamp' => now()->toIso8601String(),
         ]);
 
         throw ValidationException::withMessages([

--- a/app/Http/Controllers/Auth/ForgotPassword.php
+++ b/app/Http/Controllers/Auth/ForgotPassword.php
@@ -6,11 +6,25 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Validation\ValidationException;
 
 class ForgotPassword extends Controller
 {
+    /**
+     * Per-IP cap on reset-link requests, on top of the per-email broker throttle
+     * (config/auth.php 'throttle' => 60). The broker throttle is per-email, so it
+     * does nothing against one source requesting resets across many accounts —
+     * mail-bombing / enumeration / single-IP quota drain. This closes that gap.
+     * Resets are rare for real users, so 5/hour is generous even on a shared
+     * club/family IP. Distributed drains are surfaced by the warn-only mail monitor.
+     */
+    private const MAX_PER_IP = 5;
+
+    private const DECAY_PER_IP = 3600; // seconds (1 hour)
+
     /**
      * Handle an incoming password reset link request.
      */
@@ -23,6 +37,26 @@ class ForgotPassword extends Controller
         // Normalize so the lookup matches the lowercased stored email.
         $request->merge(['email' => User::normalizeEmail($request->email)]);
 
+        // Per-IP throttle — counts every request (valid or not) so enumeration sweeps
+        // and mail-bombing from one source are capped, each of which would send an email.
+        $ipKey = 'password-email:'.$request->ip();
+        if (RateLimiter::tooManyAttempts($ipKey, self::MAX_PER_IP)) {
+            Log::channel('security')->warning('Password reset request throttled', [
+                'event' => 'password_reset_throttled',
+                'email' => $request->email,
+                'ip' => $request->ip(),
+                'retry_after' => RateLimiter::availableIn($ipKey),
+                'user_agent' => $request->userAgent(),
+                'timestamp' => now()->toIso8601String(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Too many reset requests. Please wait a while and try again.',
+            ], 429);
+        }
+        RateLimiter::hit($ipKey, self::DECAY_PER_IP);
+
         // Send the password reset link
         $status = Password::sendResetLink(
             $request->only('email')
@@ -30,21 +64,44 @@ class ForgotPassword extends Controller
 
         // Check if the password reset link was sent successfully
         if ($status === Password::RESET_LINK_SENT) {
+            Log::channel('security')->info('Password reset link sent', [
+                'event' => 'password_reset_requested',
+                'email' => $request->email,
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+                'timestamp' => now()->toIso8601String(),
+            ]);
+
             return response()->json([
                 'success' => true,
                 'message' => 'Password reset link sent! Check your email.',
             ]);
         }
 
-        // Handle throttling
+        // Handle the per-email broker throttle (separate from the per-IP cap above)
         if ($status === Password::RESET_THROTTLED) {
+            Log::channel('security')->info('Password reset broker-throttled', [
+                'event' => 'password_reset_broker_throttled',
+                'email' => $request->email,
+                'ip' => $request->ip(),
+                'timestamp' => now()->toIso8601String(),
+            ]);
+
             return response()->json([
                 'success' => false,
                 'message' => 'Please wait before requesting another reset link.',
             ], 429);
         }
 
-        // Handle invalid user
+        // Invalid user (no matching account) — logged to surface enumeration sweeps.
+        Log::channel('security')->info('Password reset requested for unknown email', [
+            'event' => 'password_reset_invalid_user',
+            'email' => $request->email,
+            'ip' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+            'timestamp' => now()->toIso8601String(),
+        ]);
+
         throw ValidationException::withMessages([
             'email' => [trans($status)],
         ]);

--- a/app/Http/Controllers/Auth/Login.php
+++ b/app/Http/Controllers/Auth/Login.php
@@ -6,9 +6,29 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\RateLimiter;
 
 class Login extends Controller
 {
+    /**
+     * Per-account brute-force limit: failures for one email from one IP.
+     * Keyed on email+IP (not IP alone) so one member's mistyped password can't
+     * lock out others on a shared network (family / yacht-club WiFi).
+     */
+    private const MAX_PER_EMAIL_IP = 5;
+
+    private const DECAY_PER_EMAIL_IP = 60; // seconds (1 minute)
+
+    /**
+     * Coarse per-IP backstop against spraying many accounts from one source.
+     * Set well above any legitimate shared-IP behaviour (observed busiest shared
+     * IP: ~10 emails / 30 days, ~4 failures), so a club night never trips it.
+     */
+    private const MAX_PER_IP = 25;
+
+    private const DECAY_PER_IP = 900; // seconds (15 minutes)
+
     public function __invoke(Request $request)
     {
         // Validate the input
@@ -22,11 +42,23 @@ class Login extends Controller
         // lookup and Auth::attempt() use the normalized credentials.
         $credentials['email'] = User::normalizeEmail($credentials['email']);
 
+        $emailIpKey = $this->emailIpKey($credentials['email'], $request->ip());
+        $ipKey = $this->ipKey($request->ip());
+
+        // Throttle BEFORE touching the database, so a locked-out source can't even
+        // probe for account existence. Counts failures only (a success clears them).
+        if (RateLimiter::tooManyAttempts($emailIpKey, self::MAX_PER_EMAIL_IP)
+            || RateLimiter::tooManyAttempts($ipKey, self::MAX_PER_IP)) {
+            return $this->lockedOut($request, $credentials['email'], $emailIpKey, $ipKey);
+        }
+
         // Check if user exists
         $user = User::where('email', $credentials['email'])->first();
 
         if (! $user) {
             // Email doesn't exist in database
+            $this->recordFailure($emailIpKey, $ipKey);
+
             return back()
                 ->withErrors(['email' => 'No account found with this email address.'])
                 ->onlyInput('email');
@@ -34,6 +66,11 @@ class Login extends Controller
 
         // Attempt to log in
         if (Auth::attempt($credentials, $request->boolean('remember'))) {
+            // Successful login clears this account's per-email+IP counter. The coarse
+            // per-IP backstop is left to decay naturally so a single lucky guess on a
+            // shared IP doesn't reset spraying protection.
+            RateLimiter::clear($emailIpKey);
+
             // Regenerate session for security
             $request->session()->regenerate();
 
@@ -42,8 +79,55 @@ class Login extends Controller
         }
 
         // Email exists but password is wrong
+        $this->recordFailure($emailIpKey, $ipKey);
+
         return back()
             ->withErrors(['password' => 'Incorrect password.'])
             ->onlyInput('email');
+    }
+
+    /**
+     * Record a failed attempt against both limiters.
+     */
+    private function recordFailure(string $emailIpKey, string $ipKey): void
+    {
+        RateLimiter::hit($emailIpKey, self::DECAY_PER_EMAIL_IP);
+        RateLimiter::hit($ipKey, self::DECAY_PER_IP);
+    }
+
+    /**
+     * Build the locked-out response and log it to the security channel.
+     */
+    private function lockedOut(Request $request, string $email, string $emailIpKey, string $ipKey)
+    {
+        $seconds = max(
+            RateLimiter::availableIn($emailIpKey),
+            RateLimiter::availableIn($ipKey)
+        );
+
+        Log::channel('security')->warning('Login throttled', [
+            'event' => 'login_throttled',
+            'email' => $email,
+            'ip' => $request->ip(),
+            'retry_after' => $seconds,
+            'user_agent' => $request->userAgent(),
+            'timestamp' => now()->toIso8601String(),
+        ]);
+
+        $minutes = (int) ceil($seconds / 60);
+
+        return back()
+            ->withErrors(['email' => "Too many login attempts. Please try again in {$minutes} minute(s)."])
+            ->onlyInput('email');
+    }
+
+    private function emailIpKey(string $email, ?string $ip): string
+    {
+        return 'login:'.$email.'|'.$ip;
+    }
+
+    private function ipKey(?string $ip): string
+    {
+        return 'login-ip:'.$ip;
     }
 }

--- a/app/Http/Controllers/Auth/Login.php
+++ b/app/Http/Controllers/Auth/Login.php
@@ -4,10 +4,10 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Support\IpRateLimiter;
+use App\Support\SecurityLog;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\RateLimiter;
 
 class Login extends Controller
 {
@@ -42,14 +42,21 @@ class Login extends Controller
         // lookup and Auth::attempt() use the normalized credentials.
         $credentials['email'] = User::normalizeEmail($credentials['email']);
 
-        $emailIpKey = $this->emailIpKey($credentials['email'], $request->ip());
-        $ipKey = $this->ipKey($request->ip());
+        $emailIpKey = IpRateLimiter::identityKey('login', $credentials['email'], $request->ip());
+        $ipKey = IpRateLimiter::ipKey('login-ip', $request->ip());
 
         // Throttle BEFORE touching the database, so a locked-out source can't even
         // probe for account existence. Counts failures only (a success clears them).
-        if (RateLimiter::tooManyAttempts($emailIpKey, self::MAX_PER_EMAIL_IP)
-            || RateLimiter::tooManyAttempts($ipKey, self::MAX_PER_IP)) {
-            return $this->lockedOut($request, $credentials['email'], $emailIpKey, $ipKey);
+        // Track which limiter(s) tripped so the retry time reflects the actual lock,
+        // not an unrelated (untripped) limiter's still-running decay timer.
+        $emailTripped = IpRateLimiter::tooManyAttempts($emailIpKey, self::MAX_PER_EMAIL_IP);
+        $ipTripped = IpRateLimiter::tooManyAttempts($ipKey, self::MAX_PER_IP);
+
+        if ($emailTripped || $ipTripped) {
+            return $this->lockedOut($request, $credentials['email'], array_filter([
+                $emailTripped ? $emailIpKey : null,
+                $ipTripped ? $ipKey : null,
+            ]));
         }
 
         // Check if user exists
@@ -69,7 +76,7 @@ class Login extends Controller
             // Successful login clears this account's per-email+IP counter. The coarse
             // per-IP backstop is left to decay naturally so a single lucky guess on a
             // shared IP doesn't reset spraying protection.
-            RateLimiter::clear($emailIpKey);
+            IpRateLimiter::clear($emailIpKey);
 
             // Regenerate session for security
             $request->session()->regenerate();
@@ -91,27 +98,29 @@ class Login extends Controller
      */
     private function recordFailure(string $emailIpKey, string $ipKey): void
     {
-        RateLimiter::hit($emailIpKey, self::DECAY_PER_EMAIL_IP);
-        RateLimiter::hit($ipKey, self::DECAY_PER_IP);
+        IpRateLimiter::hit($emailIpKey, self::DECAY_PER_EMAIL_IP);
+        IpRateLimiter::hit($ipKey, self::DECAY_PER_IP);
     }
 
     /**
      * Build the locked-out response and log it to the security channel.
+     *
+     * @param  array<int, string>  $trippedKeys  keys of the limiter(s) actually over their cap
      */
-    private function lockedOut(Request $request, string $email, string $emailIpKey, string $ipKey)
+    private function lockedOut(Request $request, string $email, array $trippedKeys)
     {
-        $seconds = max(
-            RateLimiter::availableIn($emailIpKey),
-            RateLimiter::availableIn($ipKey)
-        );
+        // Only consider the limiter(s) that actually tripped — availableIn() returns a
+        // key's decay timer even when it is under its cap, so mixing in an untripped
+        // key would overstate the wait (e.g. report the 15-min per-IP window for a
+        // 1-min per-email lockout).
+        $seconds = 0;
+        foreach ($trippedKeys as $key) {
+            $seconds = max($seconds, IpRateLimiter::availableIn($key));
+        }
 
-        Log::channel('security')->warning('Login throttled', [
-            'event' => 'login_throttled',
+        SecurityLog::warning('login_throttled', 'Login throttled', [
             'email' => $email,
-            'ip' => $request->ip(),
             'retry_after' => $seconds,
-            'user_agent' => $request->userAgent(),
-            'timestamp' => now()->toIso8601String(),
         ]);
 
         $minutes = (int) ceil($seconds / 60);
@@ -119,15 +128,5 @@ class Login extends Controller
         return back()
             ->withErrors(['email' => "Too many login attempts. Please try again in {$minutes} minute(s)."])
             ->onlyInput('email');
-    }
-
-    private function emailIpKey(string $email, ?string $ip): string
-    {
-        return 'login:'.$email.'|'.$ip;
-    }
-
-    private function ipKey(?string $ip): string
-    {
-        return 'login-ip:'.$ip;
     }
 }

--- a/app/Http/Controllers/Auth/ResetPassword.php
+++ b/app/Http/Controllers/Auth/ResetPassword.php
@@ -2,25 +2,30 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Http\Controllers\Auth\Concerns\ThrottlesByIp;
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Support\IpRateLimiter;
+use App\Support\SecurityLog;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
 
 class ResetPassword extends Controller
 {
+    use ThrottlesByIp;
+
     /**
      * Per-IP cap on token submissions — defense-in-depth against token guessing.
      * Low risk already (tokens are long, random, 60-min expiry), but free; 10/hour
-     * is far above a legitimate user (who submits once or twice).
+     * is far above a legitimate user (who submits once or twice). Every submission
+     * is a guess attempt, so all of them count (unlike the send-only cap on the
+     * forgot-password flow).
      */
     private const MAX_PER_IP = 10;
 
@@ -42,23 +47,17 @@ class ResetPassword extends Controller
         $request->merge(['email' => User::normalizeEmail($request->email)]);
 
         // Per-IP throttle on token submissions (caps brute-force token guessing).
-        $ipKey = 'password-reset:'.$request->ip();
-        if (RateLimiter::tooManyAttempts($ipKey, self::MAX_PER_IP)) {
-            Log::channel('security')->warning('Password reset submission throttled', [
-                'event' => 'password_reset_submit_throttled',
-                'email' => $request->email,
-                'ip' => $request->ip(),
-                'retry_after' => RateLimiter::availableIn($ipKey),
-                'user_agent' => $request->userAgent(),
-                'timestamp' => now()->toIso8601String(),
-            ]);
-
-            return response()->json([
-                'success' => false,
-                'message' => 'Too many attempts. Please wait a while and try again.',
-            ], 429);
+        $ipKey = IpRateLimiter::ipKey('password-reset', $request->ip());
+        if ($throttled = $this->throttledJsonResponse(
+            $ipKey,
+            self::MAX_PER_IP,
+            'password_reset_submit_throttled',
+            'Password reset submission throttled',
+            'Too many attempts. Please wait a while and try again.'
+        )) {
+            return $throttled;
         }
-        RateLimiter::hit($ipKey, self::DECAY_PER_IP);
+        IpRateLimiter::hit($ipKey, self::DECAY_PER_IP);
 
         // Attempt to reset the user's password
         $status = Password::reset(
@@ -76,12 +75,8 @@ class ResetPassword extends Controller
 
         // Check if password was reset successfully
         if ($status === Password::PASSWORD_RESET) {
-            Log::channel('security')->info('Password reset completed', [
-                'event' => 'password_reset_completed',
+            SecurityLog::info('password_reset_completed', 'Password reset completed', [
                 'email' => $request->email,
-                'ip' => $request->ip(),
-                'user_agent' => $request->userAgent(),
-                'timestamp' => now()->toIso8601String(),
             ]);
 
             return response()->json([
@@ -92,13 +87,9 @@ class ResetPassword extends Controller
         }
 
         // Failed (bad/expired token or unknown email) — logged for visibility.
-        Log::channel('security')->warning('Password reset submission failed', [
-            'event' => 'password_reset_failed',
+        SecurityLog::warning('password_reset_failed', 'Password reset submission failed', [
             'email' => $request->email,
-            'ip' => $request->ip(),
             'status' => $status,
-            'user_agent' => $request->userAgent(),
-            'timestamp' => now()->toIso8601String(),
         ]);
 
         // Handle errors

--- a/app/Http/Controllers/Auth/ResetPassword.php
+++ b/app/Http/Controllers/Auth/ResetPassword.php
@@ -8,13 +8,24 @@ use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
 
 class ResetPassword extends Controller
 {
+    /**
+     * Per-IP cap on token submissions — defense-in-depth against token guessing.
+     * Low risk already (tokens are long, random, 60-min expiry), but free; 10/hour
+     * is far above a legitimate user (who submits once or twice).
+     */
+    private const MAX_PER_IP = 10;
+
+    private const DECAY_PER_IP = 3600; // seconds (1 hour)
+
     /**
      * Handle an incoming new password request.
      */
@@ -29,6 +40,25 @@ class ResetPassword extends Controller
         // Normalize so the lookup matches the lowercased stored email (the reset
         // link carries whatever casing was submitted to the forgot-password form).
         $request->merge(['email' => User::normalizeEmail($request->email)]);
+
+        // Per-IP throttle on token submissions (caps brute-force token guessing).
+        $ipKey = 'password-reset:'.$request->ip();
+        if (RateLimiter::tooManyAttempts($ipKey, self::MAX_PER_IP)) {
+            Log::channel('security')->warning('Password reset submission throttled', [
+                'event' => 'password_reset_submit_throttled',
+                'email' => $request->email,
+                'ip' => $request->ip(),
+                'retry_after' => RateLimiter::availableIn($ipKey),
+                'user_agent' => $request->userAgent(),
+                'timestamp' => now()->toIso8601String(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Too many attempts. Please wait a while and try again.',
+            ], 429);
+        }
+        RateLimiter::hit($ipKey, self::DECAY_PER_IP);
 
         // Attempt to reset the user's password
         $status = Password::reset(
@@ -46,12 +76,30 @@ class ResetPassword extends Controller
 
         // Check if password was reset successfully
         if ($status === Password::PASSWORD_RESET) {
+            Log::channel('security')->info('Password reset completed', [
+                'event' => 'password_reset_completed',
+                'email' => $request->email,
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+                'timestamp' => now()->toIso8601String(),
+            ]);
+
             return response()->json([
                 'success' => true,
                 'message' => 'Password reset successful! You can now login.',
                 'redirect' => route('login'),
             ]);
         }
+
+        // Failed (bad/expired token or unknown email) — logged for visibility.
+        Log::channel('security')->warning('Password reset submission failed', [
+            'event' => 'password_reset_failed',
+            'email' => $request->email,
+            'ip' => $request->ip(),
+            'status' => $status,
+            'user_agent' => $request->userAgent(),
+            'timestamp' => now()->toIso8601String(),
+        ]);
 
         // Handle errors
         throw ValidationException::withMessages([

--- a/app/Http/Controllers/VerifyEmailChangeController.php
+++ b/app/Http/Controllers/VerifyEmailChangeController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Support\SecurityLog;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 
 class VerifyEmailChangeController extends Controller
 {
@@ -57,14 +57,10 @@ class VerifyEmailChangeController extends Controller
         // Check if this is a new user verification or email change
         if ($user->pending_email) {
             // Account-takeover-relevant transition: the login email is changing. Log it.
-            Log::channel('security')->info('Email change confirmed', [
-                'event' => 'email_change_completed',
+            SecurityLog::info('email_change_completed', 'Email change confirmed', [
                 'user_id' => $user->id,
                 'old_email' => $user->email,
                 'new_email' => $user->pending_email,
-                'ip' => $request->ip(),
-                'user_agent' => $request->userAgent(),
-                'timestamp' => now()->toIso8601String(),
             ]);
 
             // Email change: Move pending_email to email

--- a/app/Http/Controllers/VerifyEmailChangeController.php
+++ b/app/Http/Controllers/VerifyEmailChangeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class VerifyEmailChangeController extends Controller
 {
@@ -55,6 +56,17 @@ class VerifyEmailChangeController extends Controller
 
         // Check if this is a new user verification or email change
         if ($user->pending_email) {
+            // Account-takeover-relevant transition: the login email is changing. Log it.
+            Log::channel('security')->info('Email change confirmed', [
+                'event' => 'email_change_completed',
+                'user_id' => $user->id,
+                'old_email' => $user->email,
+                'new_email' => $user->pending_email,
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+                'timestamp' => now()->toIso8601String(),
+            ]);
+
             // Email change: Move pending_email to email
             $user->update([
                 'email' => $user->pending_email,

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Middleware;
 
+use App\Support\SecurityLog;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 class AdminMiddleware
@@ -19,14 +19,10 @@ class AdminMiddleware
         // Check if user is authenticated and is an admin
         if (! $request->user() || ! $request->user()->is_admin) {
             // Log denied admin access so probing of /admin/* is visible in the security channel.
-            Log::channel('security')->warning('Admin access denied', [
-                'event' => 'admin_access_denied',
+            SecurityLog::warning('admin_access_denied', 'Admin access denied', [
                 'user_id' => $request->user()?->id,
                 'email' => $request->user()?->email,
-                'ip' => $request->ip(),
                 'path' => $request->path(),
-                'user_agent' => $request->userAgent(),
-                'timestamp' => now()->toIso8601String(),
             ]);
 
             abort(403, 'Unauthorized. Admin access required.');

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 class AdminMiddleware
@@ -17,6 +18,17 @@ class AdminMiddleware
     {
         // Check if user is authenticated and is an admin
         if (! $request->user() || ! $request->user()->is_admin) {
+            // Log denied admin access so probing of /admin/* is visible in the security channel.
+            Log::channel('security')->warning('Admin access denied', [
+                'event' => 'admin_access_denied',
+                'user_id' => $request->user()?->id,
+                'email' => $request->user()?->email,
+                'ip' => $request->ip(),
+                'path' => $request->path(),
+                'user_agent' => $request->userAgent(),
+                'timestamp' => now()->toIso8601String(),
+            ]);
+
             abort(403, 'Unauthorized. Admin access required.');
         }
 

--- a/app/Http/Middleware/BasicAuthMiddleware.php
+++ b/app/Http/Middleware/BasicAuthMiddleware.php
@@ -20,8 +20,10 @@ class BasicAuthMiddleware
             return $next($request);
         }
 
-        // Only apply Basic Auth in production environment
-        if (app()->environment('production')) {
+        // Apply Basic Auth in every deployed environment (production + staging/dev), never in
+        // local or testing. On staging (dev.gotflashes.com) this keeps the clone private; if no
+        // credentials are configured it falls through (the noindex header still applies there).
+        if (! app()->environment(['local', 'testing'])) {
             $username = config('auth.basic.username');
             $password = config('auth.basic.password');
 

--- a/app/Http/Middleware/BasicAuthMiddleware.php
+++ b/app/Http/Middleware/BasicAuthMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Support\SecurityLog;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,6 +39,13 @@ class BasicAuthMiddleware
 
             // Verify credentials
             if ($inputUser !== $username || $inputPass !== $password) {
+                // Log failed access to the gated (staging/dev) environment so probing is visible.
+                // Never log the submitted password — only the attempted username.
+                SecurityLog::warning('basic_auth_failed', 'Basic auth failed', [
+                    'attempted_username' => $inputUser,
+                    'path' => $request->path(),
+                ]);
+
                 return response('Unauthorized', 401)
                     ->header('WWW-Authenticate', 'Basic realm="G.O.T. Flashes Staging"');
             }

--- a/app/Http/Middleware/PreventIndexingNonProduction.php
+++ b/app/Http/Middleware/PreventIndexingNonProduction.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PreventIndexingNonProduction
+{
+    /**
+     * Add a noindex header on every non-production response so staging/dev
+     * environments (e.g. dev.gotflashes.com) are never picked up by search engines.
+     *
+     * This is the actual no-index guarantee: it prevents indexing (not just crawling),
+     * works for non-HTML responses, and is unconditional, so it holds even if the basic-auth
+     * gate's credentials are blank. Production is unaffected.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if (! app()->environment('production')) {
+            $response->headers->set('X-Robots-Tag', 'noindex, nofollow, noarchive');
+        }
+
+        return $response;
+    }
+}

--- a/app/Livewire/EmailVerificationBanner.php
+++ b/app/Livewire/EmailVerificationBanner.php
@@ -27,8 +27,12 @@ class EmailVerificationBanner extends Component
             return;
         }
 
-        // Use service to generate token and send verification email
-        EmailVerificationService::requestVerification($user, true);
+        // Use service to generate token and send verification email.
+        // isNewUser must reflect whether a pending email change is in flight: when
+        // pending_email is set, this is a change-verification and must route to (and
+        // embed the link for) the NEW address — passing true would misroute it to the
+        // current address and invalidate the correctly-routed token. Mirrors ProfileForm.
+        EmailVerificationService::requestVerification($user, ! $user->pending_email);
 
         // Record rate limit attempt
         EmailVerificationService::recordRateLimitAttempt($user);

--- a/app/Livewire/ProfileForm.php
+++ b/app/Livewire/ProfileForm.php
@@ -10,6 +10,7 @@ use App\Rules\UserProfileRules;
 use App\Services\EmailVerificationService;
 use App\Services\UserDataService;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 
 class ProfileForm extends Component
@@ -189,6 +190,18 @@ class ProfileForm extends Component
 
         // Send verification email if email changed
         if ($emailChanged) {
+            // Account-takeover-relevant transition: a new login email is being requested.
+            // ($user->email is still the old address here — only pending_email was updated.)
+            Log::channel('security')->info('Email change requested', [
+                'event' => 'email_change_initiated',
+                'user_id' => $user->id,
+                'old_email' => $user->email,
+                'new_email' => $validated['email'],
+                'ip' => request()->ip(),
+                'user_agent' => request()->userAgent(),
+                'timestamp' => now()->toIso8601String(),
+            ]);
+
             // Send verification to new email
             EmailVerificationService::sendVerification($user, false);
 

--- a/app/Livewire/ProfileForm.php
+++ b/app/Livewire/ProfileForm.php
@@ -9,8 +9,8 @@ use App\Models\User;
 use App\Rules\UserProfileRules;
 use App\Services\EmailVerificationService;
 use App\Services\UserDataService;
+use App\Support\SecurityLog;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 
 class ProfileForm extends Component
@@ -192,14 +192,10 @@ class ProfileForm extends Component
         if ($emailChanged) {
             // Account-takeover-relevant transition: a new login email is being requested.
             // ($user->email is still the old address here — only pending_email was updated.)
-            Log::channel('security')->info('Email change requested', [
-                'event' => 'email_change_initiated',
+            SecurityLog::info('email_change_initiated', 'Email change requested', [
                 'user_id' => $user->id,
                 'old_email' => $user->email,
                 'new_email' => $validated['email'],
-                'ip' => request()->ip(),
-                'user_agent' => request()->userAgent(),
-                'timestamp' => now()->toIso8601String(),
             ]);
 
             // Send verification to new email

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Notifications\ResetPasswordNotification;
+use App\Notifications\VerifyEmailChange;
 use Carbon\Carbon;
 use Database\Factories\UserFactory;
 use Illuminate\Auth\Passwords\CanResetPassword;
@@ -13,6 +14,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
 use Illuminate\Support\Str;
 
 class User extends Authenticatable
@@ -122,6 +124,25 @@ class User extends Authenticatable
     public function sendPasswordResetNotification($token): void
     {
         $this->notify(new ResetPasswordNotification($token));
+    }
+
+    /**
+     * Route notifications for the mail channel.
+     *
+     * An email-change verification must be delivered to the NEW (pending) address being
+     * verified — never the current one — so clicking the link proves control of the new inbox.
+     * All other mail (password reset, award notices, new-user verification) routes to the
+     * current address. Scoped to VerifyEmailChange-during-change so nothing else is misrouted,
+     * e.g. a password reset while an unverified email change is pending still goes to the
+     * current address.
+     */
+    public function routeNotificationForMail(Notification $notification): string
+    {
+        if ($notification instanceof VerifyEmailChange && ! $notification->isNewUser && $this->pending_email) {
+            return $this->pending_email;
+        }
+
+        return $this->email;
     }
 
     public function flashes(): HasMany

--- a/app/Policies/FlashPolicy.php
+++ b/app/Policies/FlashPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\Flash;
 use App\Models\User;
+use App\Support\SecurityLog;
 
 class FlashPolicy
 {
@@ -36,7 +37,7 @@ class FlashPolicy
      */
     public function update(User $user, Flash $flash): bool
     {
-        return $flash->user_id === $user->id;
+        return $this->ownsOrLogDenied('update', $user, $flash);
     }
 
     /**
@@ -44,7 +45,28 @@ class FlashPolicy
      */
     public function delete(User $user, Flash $flash): bool
     {
-        return $flash->user_id === $user->id;
+        return $this->ownsOrLogDenied('delete', $user, $flash);
+    }
+
+    /**
+     * Ownership check shared by the update/delete abilities: logs a security event
+     * on denial (surfaces IDOR/ownership-probing that otherwise only shows as an
+     * opaque 403) and returns whether the user owns the flash.
+     */
+    private function ownsOrLogDenied(string $ability, User $user, Flash $flash): bool
+    {
+        $owns = $flash->user_id === $user->id;
+
+        if (! $owns) {
+            SecurityLog::warning('flash_authorization_denied', 'Flash authorization denied', [
+                'ability' => $ability,
+                'user_id' => $user->id,
+                'flash_id' => $flash->id,
+                'flash_owner_id' => $flash->user_id,
+            ]);
+        }
+
+        return $owns;
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,8 +23,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // Force HTTPS in production
-        if (app()->environment('production')) {
+        // Force HTTPS in every deployed environment (production + staging/dev), never in
+        // local or testing. Upstream TLS terminates at Cloudflare/HAProxy so the app sees
+        // plain HTTP; without this, route()/redirects on staging emit http:// URLs and the
+        // AJAX forms (forgot/reset password) get mixed-content-blocked. Matches the
+        // deployed-env gate used by BasicAuthMiddleware.
+        if (! app()->environment(['local', 'testing'])) {
             URL::forceScheme('https');
         }
 

--- a/app/Providers/ObservabilityServiceProvider.php
+++ b/app/Providers/ObservabilityServiceProvider.php
@@ -119,6 +119,10 @@ class ObservabilityServiceProvider extends ServiceProvider
             // "=== threshold" would miss the warning entirely on any skipped/reset count.
             if (is_int($count) && $count >= self::MAIL_VOLUME_WARN_THRESHOLD
                 && Cache::add('mail-volume-warned:'.now()->toDateString(), true, now()->endOfDay())) {
+                // Logged directly (not via SecurityLog) on purpose: this is a cumulative daily
+                // aggregate, not a per-request event. It can fire from a queue worker with no
+                // request, and stamping it with the ip/user_agent of whichever send happened to
+                // cross the threshold would falsely implicate that one client for the whole day.
                 Log::channel('security')->warning('Transactional email volume approaching daily cap', [
                     'event' => 'mail_volume_warning',
                     'sent_today' => $count,

--- a/app/Providers/ObservabilityServiceProvider.php
+++ b/app/Providers/ObservabilityServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Http\Middleware\AuthenticationLoggingMiddleware;
 use App\Http\Middleware\RequestLoggingMiddleware;
 use App\Listeners\QueryLogListener;
+use App\Support\SecurityLog;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
@@ -77,12 +78,10 @@ class ObservabilityServiceProvider extends ServiceProvider
 
         // Log authentication events
         Event::listen(Login::class, function ($event) {
-            Log::channel('security')->info('User logged in', [
-                'event' => 'login_success',
+            SecurityLog::info('login_success', 'User logged in', [
                 'user_id' => $event->user->id,
                 'email' => $event->user->email,
                 'remember' => $event->remember,
-                'timestamp' => now()->toIso8601String(),
             ]);
 
             // Store login timestamp in session for duration tracking
@@ -90,20 +89,16 @@ class ObservabilityServiceProvider extends ServiceProvider
         });
 
         Event::listen(Failed::class, function ($event) {
-            Log::channel('security')->warning('Authentication failed', [
-                'event' => 'auth_failed',
+            SecurityLog::warning('auth_failed', 'Authentication failed', [
                 'email' => $event->credentials['email'] ?? null,
                 'guard' => $event->guard,
-                'timestamp' => now()->toIso8601String(),
             ]);
         });
 
         Event::listen(Registered::class, function ($event) {
-            Log::channel('security')->info('New user registered', [
-                'event' => 'user_registered',
+            SecurityLog::info('user_registered', 'New user registered', [
                 'user_id' => $event->user->id,
                 'email' => $event->user->email,
-                'timestamp' => now()->toIso8601String(),
             ]);
         });
 
@@ -112,18 +107,23 @@ class ObservabilityServiceProvider extends ServiceProvider
         Event::listen(MessageSent::class, function () {
             $key = 'mail-sent-count:'.now()->toDateString();
 
-            if (! Cache::has($key)) {
-                Cache::put($key, 0, now()->endOfDay());
-            }
+            // add() is atomic put-if-absent, so concurrent first-of-day sends can't
+            // clobber each other's count (a plain has()/put() pair could reset it to 0).
+            // The key TTL is endOfDay, which is the intended midnight daily reset.
+            Cache::add($key, 0, now()->endOfDay());
             $count = Cache::increment($key);
 
-            if ($count === self::MAIL_VOLUME_WARN_THRESHOLD) {
+            // Warn once per day when crossing the threshold. The separate warned-flag
+            // (also atomic add()) means a cache flush that resets the counter mid-day
+            // and re-crosses the threshold won't emit a second alert, while a strict
+            // "=== threshold" would miss the warning entirely on any skipped/reset count.
+            if (is_int($count) && $count >= self::MAIL_VOLUME_WARN_THRESHOLD
+                && Cache::add('mail-volume-warned:'.now()->toDateString(), true, now()->endOfDay())) {
                 Log::channel('security')->warning('Transactional email volume approaching daily cap', [
                     'event' => 'mail_volume_warning',
                     'sent_today' => $count,
                     'warn_threshold' => self::MAIL_VOLUME_WARN_THRESHOLD,
                     'provider_daily_cap' => self::MAIL_PROVIDER_DAILY_CAP,
-                    'timestamp' => now()->toIso8601String(),
                 ]);
             }
         });

--- a/app/Providers/ObservabilityServiceProvider.php
+++ b/app/Providers/ObservabilityServiceProvider.php
@@ -10,12 +10,24 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class ObservabilityServiceProvider extends ServiceProvider
 {
+    /**
+     * Warn-only transactional-email volume monitor. The provider (Resend free) caps
+     * at 100 emails/day; we alert as we approach it so a quota drain is visible
+     * in-app. This deliberately does NOT block — the per-IP/per-email throttles do the
+     * source-level enforcement, and a blocking cap would drop legitimate mail.
+     */
+    private const MAIL_VOLUME_WARN_THRESHOLD = 80;
+
+    private const MAIL_PROVIDER_DAILY_CAP = 100;
+
     /**
      * Register services.
      */
@@ -93,6 +105,27 @@ class ObservabilityServiceProvider extends ServiceProvider
                 'email' => $event->user->email,
                 'timestamp' => now()->toIso8601String(),
             ]);
+        });
+
+        // Warn-only daily email-volume monitor (alert, do not block). Surfaces a
+        // distributed quota drain that per-IP/per-email throttles can't catch.
+        Event::listen(MessageSent::class, function () {
+            $key = 'mail-sent-count:'.now()->toDateString();
+
+            if (! Cache::has($key)) {
+                Cache::put($key, 0, now()->endOfDay());
+            }
+            $count = Cache::increment($key);
+
+            if ($count === self::MAIL_VOLUME_WARN_THRESHOLD) {
+                Log::channel('security')->warning('Transactional email volume approaching daily cap', [
+                    'event' => 'mail_volume_warning',
+                    'sent_today' => $count,
+                    'warn_threshold' => self::MAIL_VOLUME_WARN_THRESHOLD,
+                    'provider_daily_cap' => self::MAIL_PROVIDER_DAILY_CAP,
+                    'timestamp' => now()->toIso8601String(),
+                ]);
+            }
         });
     }
 

--- a/app/Services/EmailVerificationService.php
+++ b/app/Services/EmailVerificationService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\User;
 use App\Notifications\VerifyEmailChange;
+use App\Support\SecurityLog;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 
@@ -39,6 +40,14 @@ class EmailVerificationService
     public static function sendVerification(User $user, bool $isNewUser = true): void
     {
         $user->notify(new VerifyEmailChange($user->email_verification_token, $isNewUser));
+
+        // Verification/change emails draw on the finite transactional-mail quota; log sends so
+        // resend abuse is visible (mirrors the reset-flow logging in ForgotPassword).
+        SecurityLog::info('verification_email_sent', 'Verification email sent', [
+            'user_id' => $user->id,
+            'email' => $isNewUser ? $user->email : ($user->pending_email ?? $user->email),
+            'is_new_user' => $isNewUser,
+        ]);
     }
 
     /**
@@ -64,6 +73,8 @@ class EmailVerificationService
             $seconds = RateLimiter::availableIn($rateLimitKey);
             $minutes = ceil($seconds / 60);
 
+            self::logThrottled($user, 'cooldown', $seconds);
+
             return [
                 'allowed' => false,
                 'type' => 'warning',
@@ -74,7 +85,10 @@ class EmailVerificationService
         // Check hourly limit
         $hourlyLimitKey = 'resend-verification-hourly:'.$user->id;
         if (RateLimiter::tooManyAttempts($hourlyLimitKey, self::RATE_LIMIT_PER_HOUR)) {
-            $minutes = ceil(RateLimiter::availableIn($hourlyLimitKey) / 60);
+            $seconds = RateLimiter::availableIn($hourlyLimitKey);
+            $minutes = ceil($seconds / 60);
+
+            self::logThrottled($user, 'hourly', $seconds);
 
             return [
                 'allowed' => false,
@@ -88,6 +102,19 @@ class EmailVerificationService
             'type' => null,
             'message' => null,
         ];
+    }
+
+    /**
+     * Log a verification-resend throttle hit so quota-drain attempts are visible.
+     */
+    private static function logThrottled(User $user, string $limit, int $retryAfter): void
+    {
+        SecurityLog::warning('verification_resend_throttled', 'Verification resend throttled', [
+            'limit' => $limit,
+            'user_id' => $user->id,
+            'email' => $user->email,
+            'retry_after' => $retryAfter,
+        ]);
     }
 
     /**

--- a/app/Support/IpRateLimiter.php
+++ b/app/Support/IpRateLimiter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\RateLimiter;
+
+/**
+ * Shared per-IP / per-identity throttle helper.
+ *
+ * Owns rate-limiter key construction so the format lives in one place, and hashes
+ * any user-supplied component (e.g. an email) into the key. Laravel's RateLimiter
+ * runs htmlentities()+entity-stripping over raw keys, which collapses distinct
+ * RFC-valid emails onto the same bucket (josé@x.com vs jose@x.com); hashing the
+ * identity first removes that collision.
+ */
+class IpRateLimiter
+{
+    /**
+     * Build a key scoped to a single IP: e.g. "password-email:1.2.3.4".
+     */
+    public static function ipKey(string $prefix, ?string $ip): string
+    {
+        return $prefix.':'.$ip;
+    }
+
+    /**
+     * Build a key scoped to an identity (email) + IP, with the identity hashed so
+     * special characters cannot alias one account's bucket onto another's.
+     */
+    public static function identityKey(string $prefix, string $identity, ?string $ip): string
+    {
+        return $prefix.':'.hash('sha256', $identity).'|'.$ip;
+    }
+
+    public static function tooManyAttempts(string $key, int $maxAttempts): bool
+    {
+        return RateLimiter::tooManyAttempts($key, $maxAttempts);
+    }
+
+    public static function hit(string $key, int $decaySeconds): void
+    {
+        RateLimiter::hit($key, $decaySeconds);
+    }
+
+    public static function availableIn(string $key): int
+    {
+        return RateLimiter::availableIn($key);
+    }
+
+    public static function clear(string $key): void
+    {
+        RateLimiter::clear($key);
+    }
+}

--- a/app/Support/IpRateLimiter.php
+++ b/app/Support/IpRateLimiter.php
@@ -17,6 +17,10 @@ class IpRateLimiter
 {
     /**
      * Build a key scoped to a single IP: e.g. "password-email:1.2.3.4".
+     *
+     * The IP is not hashed (unlike identityKey's identity): $request->ip() is never
+     * attacker-supplied free text on this stack (CF-only firewall + nginx realip resolve
+     * it), and IPv4/IPv6 literals contain no characters that cleanRateLimiterKey() mangles.
      */
     public static function ipKey(string $prefix, ?string $ip): string
     {

--- a/app/Support/SecurityLog.php
+++ b/app/Support/SecurityLog.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Thin helper for the `security` log channel.
+ *
+ * Injects request context (ip / user_agent / request_id) once so call sites can
+ * pass just the event slug, a human message, and event-specific fields. There is
+ * deliberately no `timestamp` field: the channel's Monolog JsonFormatter already
+ * emits `datetime`, so a hand-added timestamp only duplicates it.
+ *
+ * The request_id ties a security event back to the matching RequestLoggingMiddleware
+ * entry on the `structured` channel (it sets the X-Request-ID header per request).
+ */
+class SecurityLog
+{
+    public static function info(string $event, string $message, array $context = []): void
+    {
+        self::write('info', $event, $message, $context);
+    }
+
+    public static function warning(string $event, string $message, array $context = []): void
+    {
+        self::write('warning', $event, $message, $context);
+    }
+
+    private static function write(string $level, string $event, string $message, array $context): void
+    {
+        $request = request();
+
+        // Filter the auto-injected fields (null in console/queue contexts); leave the
+        // caller's context untouched so intentional nulls (e.g. user_id) are preserved.
+        $base = array_filter([
+            'event' => $event,
+            'ip' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+            'request_id' => $request->headers->get('X-Request-ID'),
+        ], static fn ($value) => $value !== null);
+
+        $payload = array_merge($base, $context);
+
+        $logger = Log::channel('security');
+
+        match ($level) {
+            'warning' => $logger->warning($message, $payload),
+            default => $logger->info($message, $payload),
+        };
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,7 +17,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        // Trust HAProxy (on pfSense) and recognize forwarded headers
+        // Defense-in-depth only. nginx (docker/nginx.conf) owns real-client-IP resolution
+        // via the realip module + CF-Connecting-IP, rewriting REMOTE_ADDR to the true client
+        // before PHP sees it, so this does not drive $request->ip() and HTTPS is owned by
+        // AppServiceProvider's forceScheme. Do not point logic (IP logging, rate limiting) at
+        // it — see the "Proxy & Real Client IP" note in CLAUDE.md.
         $middleware->trustProxies(
             at: env('TRUSTED_PROXY_IP'),
             headers: Request::HEADER_X_FORWARDED_FOR |
@@ -26,9 +30,11 @@ return Application::configure(basePath: dirname(__DIR__))
         );
 
         $middleware->append(ContentSecurityPolicy::class);
-        $middleware->append(BasicAuthMiddleware::class);
         // Keep non-production environments (dev.gotflashes.com) out of search indexes.
+        // Appended before BasicAuthMiddleware so it wraps the gate: a 401 challenge from
+        // basic auth still carries the noindex header on its way out.
         $middleware->append(PreventIndexingNonProduction::class);
+        $middleware->append(BasicAuthMiddleware::class);
         $middleware->alias([
             'admin' => AdminMiddleware::class,
         ]);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\AdminMiddleware;
 use App\Http\Middleware\BasicAuthMiddleware;
 use App\Http\Middleware\ContentSecurityPolicy;
+use App\Http\Middleware\PreventIndexingNonProduction;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -26,6 +27,8 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->append(ContentSecurityPolicy::class);
         $middleware->append(BasicAuthMiddleware::class);
+        // Keep non-production environments (dev.gotflashes.com) out of search indexes.
+        $middleware->append(PreventIndexingNonProduction::class);
         $middleware->alias([
             'admin' => AdminMiddleware::class,
         ]);

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -11,10 +11,12 @@ http {
     # Treat files with unknown filetype as binary
     default_type application/octet-stream;
 
-    # Define custom log format to include response times
+    # Define custom log format to include response times.
+    # cf="$http_cf_connecting_ip" is a diagnostic to verify on dev that Cloudflare's real-client
+    # header arrives (it's the source $remote_addr is resolved from). Safe to drop once verified.
     log_format main_timed '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '
-                          '"$http_user_agent" "$http_x_forwarded_for" '
+                          '"$http_user_agent" "$http_x_forwarded_for" cf="$http_cf_connecting_ip" '
                           '$request_time $upstream_response_time $pipe';
 
     # Write access logs to mounted storage/logs directory instead of stdout to reduce console noise
@@ -57,10 +59,15 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
 
-        # Trust HAProxy for real IP forwarding
+        # Real client IP resolution.
+        # set_real_ip_from 0.0.0.0/0 is intentional: a pfSense firewall rule restricts port
+        # 80/443 ingress to Cloudflare IPs, so the only possible upstream is Cloudflare -> HAProxy
+        # (no Cloudflare range list to maintain here — the firewall is the enforcement).
+        # CF-Connecting-IP is set by Cloudflare to the true client and overwrites any
+        # client-supplied value, so it is NOT spoofable — unlike the leftmost X-Forwarded-For,
+        # which a client can pre-seed (CF appends rather than replaces XFF).
         set_real_ip_from 0.0.0.0/0;
-        real_ip_header X-Forwarded-For;
-        real_ip_recursive on;
+        real_ip_header CF-Connecting-IP;
 
         # Max upload size
         client_max_body_size 10M;
@@ -99,8 +106,10 @@ http {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $fastcgi_path_info;
 
-            # Forward real IP and protocol from HAProxy
-            fastcgi_param REMOTE_ADDR $http_x_forwarded_for;
+            # REMOTE_ADDR is provided by fastcgi_params as $remote_addr, which the realip
+            # module above has already resolved to the real client IP (verified against
+            # nginx-access.log field 1). Do NOT override it with the raw $http_x_forwarded_for
+            # header — that yields a "client, cf-edge" two-IP string and breaks $request->ip().
             fastcgi_param HTTP_X_FORWARDED_FOR $http_x_forwarded_for;
             fastcgi_param HTTP_X_FORWARDED_PROTO $http_x_forwarded_proto;
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -11,12 +11,10 @@ http {
     # Treat files with unknown filetype as binary
     default_type application/octet-stream;
 
-    # Define custom log format to include response times.
-    # cf="$http_cf_connecting_ip" is a diagnostic to verify on dev that Cloudflare's real-client
-    # header arrives (it's the source $remote_addr is resolved from). Safe to drop once verified.
+    # Define custom log format to include response times
     log_format main_timed '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '
-                          '"$http_user_agent" "$http_x_forwarded_for" cf="$http_cf_connecting_ip" '
+                          '"$http_user_agent" "$http_x_forwarded_for" '
                           '$request_time $upstream_response_time $pipe';
 
     # Write access logs to mounted storage/logs directory instead of stdout to reduce console noise

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,3 +10,10 @@ Artisan::command('inspire', function () {
 
 // Daily database backup at 2:00 AM (UTC)
 Schedule::command('db:backup')->daily()->at('02:00');
+
+// Prune expired rows from the database cache store. The store only evicts expired
+// rows lazily when the same key is read again, so short-lived rate-limiter keys
+// (login:, login-ip:, password-email:, password-reset:) from rotating IPs would
+// otherwise accumulate forever in the app's SQLite DB — and get copied into every
+// daily backup. Runs after the backup so the next backup sees the pruned DB.
+Schedule::command('cache:prune-expired')->daily()->at('02:30');

--- a/tests/Feature/Auth/LoginRateLimitTest.php
+++ b/tests/Feature/Auth/LoginRateLimitTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
+use App\Support\IpRateLimiter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\RateLimiter;
 use Tests\TestCase;
@@ -58,8 +59,54 @@ class LoginRateLimitTest extends TestCase
         $this->assertAuthenticated();
         $response->assertRedirect(route('logbook.index'));
 
-        // The per-email+IP counter was cleared on success.
-        $this->assertSame(0, RateLimiter::attempts('login:u@example.com|127.0.0.1'));
+        // The per-email+IP counter was cleared on success. The key hashes the email
+        // (so special chars can't alias one account's bucket onto another's).
+        $this->assertSame(
+            0,
+            RateLimiter::attempts(IpRateLimiter::identityKey('login', 'u@example.com', '127.0.0.1'))
+        );
+    }
+
+    public function test_lockout_message_reports_the_short_per_account_window_not_the_ip_backstop(): void
+    {
+        User::factory()->create([
+            'email' => 'victim@example.com',
+            'password' => bcrypt('password123'),
+        ]);
+
+        // 5 rapid failures trip only the 60s per-email+IP limit (well under the 25/IP
+        // backstop). The retry time must reflect that ~1-minute window, not the
+        // untripped per-IP limiter's 15-minute decay timer.
+        for ($i = 0; $i < 6; $i++) {
+            $response = $this->post('/login', ['email' => 'victim@example.com', 'password' => 'wrong']);
+        }
+
+        $message = session('errors')->get('email')[0];
+        $this->assertStringContainsString('Too many login attempts', $message);
+        $this->assertStringContainsString('1 minute(s)', $message);
+        $this->assertStringNotContainsString('15 minute', $message);
+    }
+
+    public function test_coarse_per_ip_backstop_locks_out_spraying_across_accounts(): void
+    {
+        // Spray 25 failures across distinct (non-existent) accounts from one IP so the
+        // per-email+IP limiter never trips but the coarse 25/IP backstop does.
+        for ($i = 0; $i < 25; $i++) {
+            $this->post('/login', ['email' => "spray{$i}@example.com", 'password' => 'wrong']);
+        }
+
+        // A brand-new account from the same IP is now blocked by the per-IP backstop,
+        // even though its own per-email+IP counter is empty.
+        User::factory()->create(['email' => 'target@example.com', 'password' => bcrypt('password123')]);
+
+        $response = $this->post('/login', [
+            'email' => 'target@example.com',
+            'password' => 'password123',
+        ]);
+
+        $this->assertGuest();
+        $response->assertSessionHasErrors('email');
+        $this->assertStringContainsString('Too many login attempts', session('errors')->get('email')[0]);
     }
 
     public function test_throttling_one_account_does_not_block_another_on_the_same_ip(): void

--- a/tests/Feature/Auth/LoginRateLimitTest.php
+++ b/tests/Feature/Auth/LoginRateLimitTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class LoginRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_is_throttled_after_too_many_failed_attempts(): void
+    {
+        User::factory()->create([
+            'email' => 'victim@example.com',
+            'password' => bcrypt('password123'),
+        ]);
+
+        // 5 failed attempts are allowed (the per-email+IP limit).
+        for ($i = 0; $i < 5; $i++) {
+            $this->post('/login', ['email' => 'victim@example.com', 'password' => 'wrong']);
+        }
+
+        // The 6th is throttled — even with the CORRECT password, since the throttle
+        // check runs before authentication.
+        $response = $this->post('/login', [
+            'email' => 'victim@example.com',
+            'password' => 'password123',
+        ]);
+
+        $this->assertGuest();
+        $response->assertSessionHasErrors('email');
+        $this->assertStringContainsString(
+            'Too many login attempts',
+            session('errors')->get('email')[0]
+        );
+    }
+
+    public function test_successful_login_clears_the_per_account_counter(): void
+    {
+        User::factory()->create([
+            'email' => 'u@example.com',
+            'password' => bcrypt('password123'),
+        ]);
+
+        // 4 failures — under the limit, so a correct login still goes through.
+        for ($i = 0; $i < 4; $i++) {
+            $this->post('/login', ['email' => 'u@example.com', 'password' => 'wrong']);
+        }
+
+        $response = $this->post('/login', [
+            'email' => 'u@example.com',
+            'password' => 'password123',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(route('logbook.index'));
+
+        // The per-email+IP counter was cleared on success.
+        $this->assertSame(0, RateLimiter::attempts('login:u@example.com|127.0.0.1'));
+    }
+
+    public function test_throttling_one_account_does_not_block_another_on_the_same_ip(): void
+    {
+        User::factory()->create(['email' => 'a@example.com', 'password' => bcrypt('password123')]);
+        User::factory()->create(['email' => 'b@example.com', 'password' => bcrypt('password123')]);
+
+        // Lock out account A from this IP (shared club/family WiFi scenario).
+        for ($i = 0; $i < 6; $i++) {
+            $this->post('/login', ['email' => 'a@example.com', 'password' => 'wrong']);
+        }
+
+        // Account B can still log in from the same IP — keying is email+IP, not IP alone.
+        $response = $this->post('/login', [
+            'email' => 'b@example.com',
+            'password' => 'password123',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(route('logbook.index'));
+    }
+}

--- a/tests/Feature/Auth/PasswordResetRateLimitTest.php
+++ b/tests/Feature/Auth/PasswordResetRateLimitTest.php
@@ -30,6 +30,25 @@ class PasswordResetRateLimitTest extends TestCase
             ->assertJson(['message' => 'Too many reset requests. Please wait a while and try again.']);
     }
 
+    public function test_requests_that_send_no_mail_do_not_consume_the_per_ip_budget(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        // Ten requests for non-existent accounts send no mail, so they must NOT count
+        // toward the per-IP cap — only actual sends do. Otherwise a legit user (or a
+        // neighbour behind the same NAT) gets locked out of account recovery.
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson(route('password.email'), ['email' => "ghost{$i}@example.com"])
+                ->assertStatus(422);
+        }
+
+        // The real account can still request a reset — the budget was never drained.
+        $this->postJson(route('password.email'), ['email' => $user->email])
+            ->assertStatus(200);
+    }
+
     public function test_token_submissions_are_capped_per_ip(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Auth/PasswordResetRateLimitTest.php
+++ b/tests/Feature/Auth/PasswordResetRateLimitTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class PasswordResetRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reset_requests_are_capped_per_ip_across_different_accounts(): void
+    {
+        Notification::fake();
+
+        // Six distinct accounts so the per-EMAIL broker throttle never fires — this
+        // isolates the per-IP cap, i.e. the mail-bomb / enumeration scenario.
+        $users = User::factory()->count(6)->create();
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->postJson(route('password.email'), ['email' => $users[$i]->email])
+                ->assertStatus(200);
+        }
+
+        // 6th distinct email from the same IP trips the per-IP cap (5/hour).
+        $this->postJson(route('password.email'), ['email' => $users[5]->email])
+            ->assertStatus(429)
+            ->assertJson(['message' => 'Too many reset requests. Please wait a while and try again.']);
+    }
+
+    public function test_token_submissions_are_capped_per_ip(): void
+    {
+        $user = User::factory()->create();
+
+        $payload = [
+            'token' => 'invalid-token',
+            'email' => $user->email,
+            'password' => 'new-password123',
+            'password_confirmation' => 'new-password123',
+        ];
+
+        // 10 submissions are allowed (each fails validation of the token → 422).
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson(route('password.update'), $payload)->assertStatus(422);
+        }
+
+        // 11th from the same IP is throttled before the reset is attempted.
+        $this->postJson(route('password.update'), $payload)
+            ->assertStatus(429)
+            ->assertJson(['message' => 'Too many attempts. Please wait a while and try again.']);
+    }
+}

--- a/tests/Feature/BasicAuthMiddlewareTest.php
+++ b/tests/Feature/BasicAuthMiddlewareTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class BasicAuthMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Put the app into a gated (deployed, non-local/testing) environment with basic-auth
+     * credentials configured. The suite otherwise runs as `testing`, where the gate is a
+     * deliberate no-op, so the 401 path can only be exercised by overriding the env.
+     */
+    private function gateAsStaging(): void
+    {
+        $this->app['env'] = 'staging';
+        config([
+            'auth.basic.username' => 'devuser',
+            'auth.basic.password' => 'devpass',
+        ]);
+    }
+
+    private function authHeader(string $user, string $pass): array
+    {
+        return ['Authorization' => 'Basic '.base64_encode($user.':'.$pass)];
+    }
+
+    public function test_gated_environment_challenges_when_no_credentials_supplied(): void
+    {
+        $this->gateAsStaging();
+
+        $this->get('/')
+            ->assertStatus(401)
+            ->assertHeader('WWW-Authenticate', 'Basic realm="G.O.T. Flashes Staging"');
+    }
+
+    public function test_the_401_challenge_still_carries_the_noindex_header(): void
+    {
+        // Pins the middleware ordering: PreventIndexingNonProduction is appended ahead of
+        // BasicAuthMiddleware, so even its short-circuit 401 is wrapped and gets X-Robots-Tag.
+        $this->gateAsStaging();
+
+        $this->get('/')
+            ->assertStatus(401)
+            ->assertHeader('X-Robots-Tag', 'noindex, nofollow, noarchive');
+    }
+
+    public function test_correct_credentials_pass_through(): void
+    {
+        $this->gateAsStaging();
+
+        $this->withHeaders($this->authHeader('devuser', 'devpass'))
+            ->get('/')
+            ->assertStatus(200);
+    }
+
+    public function test_gate_is_a_noop_in_the_testing_environment(): void
+    {
+        // Default suite env is 'testing' — the gate must not fire even with creds set,
+        // so local/CI request cycles are never challenged.
+        config([
+            'auth.basic.username' => 'devuser',
+            'auth.basic.password' => 'devpass',
+        ]);
+
+        $this->get('/')->assertStatus(200);
+    }
+
+    public function test_blank_credentials_fall_through_even_in_a_gated_environment(): void
+    {
+        // With no BASIC_AUTH_* configured the gate falls through (noindex still applies).
+        $this->app['env'] = 'staging';
+        config(['auth.basic.username' => null, 'auth.basic.password' => null]);
+
+        $this->get('/')->assertStatus(200);
+    }
+
+    public function test_failed_attempt_is_logged_without_the_submitted_password(): void
+    {
+        $entries = [];
+        Event::listen(MessageLogged::class, function (MessageLogged $event) use (&$entries) {
+            if (($event->context['event'] ?? null) === 'basic_auth_failed') {
+                $entries[] = $event->context;
+            }
+        });
+
+        $this->gateAsStaging();
+
+        $this->withHeaders($this->authHeader('devuser', 'wrong-password'))
+            ->get('/')
+            ->assertStatus(401);
+
+        $this->assertCount(1, $entries);
+        $this->assertSame('devuser', $entries[0]['attempted_username']);
+        // The submitted password must never reach the logs.
+        $this->assertStringNotContainsString('wrong-password', json_encode($entries[0]));
+    }
+}

--- a/tests/Feature/DevEnvironmentGuardTest.php
+++ b/tests/Feature/DevEnvironmentGuardTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DevEnvironmentGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_noindex_header_is_sent_in_non_production(): void
+    {
+        // The test suite runs as a non-production environment, so the guard applies.
+        $this->assertFalse(app()->environment('production'));
+
+        $this->get('/')
+            ->assertHeader('X-Robots-Tag', 'noindex, nofollow, noarchive');
+    }
+}

--- a/tests/Feature/DevEnvironmentGuardTest.php
+++ b/tests/Feature/DevEnvironmentGuardTest.php
@@ -17,4 +17,15 @@ class DevEnvironmentGuardTest extends TestCase
         $this->get('/')
             ->assertHeader('X-Robots-Tag', 'noindex, nofollow, noarchive');
     }
+
+    public function test_https_is_not_forced_in_local_or_testing(): void
+    {
+        // AppServiceProvider forces https on every deployed env (! local/testing) so
+        // staging URLs/forms aren't emitted as http:// behind upstream TLS. This guards
+        // the exclusion: if it regressed to include testing, generated URLs would flip
+        // to https and break the local/CI request cycle. (Staging/prod https itself is
+        // verified manually — the app boots once as 'testing' in the suite.)
+        $this->assertTrue(app()->environment('testing'));
+        $this->assertStringStartsWith('http://', route('login'));
+    }
 }

--- a/tests/Feature/EmailVerificationTest.php
+++ b/tests/Feature/EmailVerificationTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Livewire\EmailVerificationBanner;
+use App\Livewire\ProfileForm;
 use App\Livewire\RegistrationForm;
 use App\Models\User;
+use App\Notifications\ResetPasswordNotification;
+use App\Notifications\VerifyEmailChange;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
@@ -158,6 +162,109 @@ class EmailVerificationTest extends TestCase
         // New email should be pending
         $this->assertEquals('new@example.com', $user->pending_email);
         $this->assertNotNull($user->email_verification_token);
+    }
+
+    // ============================================
+    // Email-change verification is delivered to the NEW address (recipient routing)
+    // ============================================
+
+    public function test_email_change_verification_routes_to_new_pending_address(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'old@example.com',
+            'pending_email' => 'new@example.com',
+        ]);
+
+        // A change-verification (isNewUser: false) must be delivered to the NEW address being
+        // verified, so clicking the link proves control of the new inbox — not the old one.
+        $recipient = $user->routeNotificationForMail(new VerifyEmailChange('token', false));
+
+        $this->assertSame('new@example.com', $recipient);
+    }
+
+    public function test_new_user_verification_routes_to_current_address(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'current@example.com',
+            'pending_email' => null,
+        ]);
+
+        // New-user registration verification (isNewUser: true, no pending change) → current email.
+        $recipient = $user->routeNotificationForMail(new VerifyEmailChange('token', true));
+
+        $this->assertSame('current@example.com', $recipient);
+    }
+
+    public function test_other_mail_is_not_misrouted_while_an_email_change_is_pending(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'current@example.com',
+            'pending_email' => 'pending@example.com',
+        ]);
+
+        // Regression guard for the routing fix: a password reset must still go to the CURRENT
+        // (verified) address even while an unverified email change is pending — never the
+        // pending address (which the user has not yet proven they control).
+        $recipient = $user->routeNotificationForMail(new ResetPasswordNotification('token'));
+
+        $this->assertSame('current@example.com', $recipient);
+    }
+
+    public function test_email_change_flow_delivers_verification_to_the_new_address(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(ProfileForm::class)
+            ->set('email', 'jane@example.com')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        // End-to-end guard: changing the email must send the change-verification, resolved to
+        // the new pending address rather than the old login email.
+        Notification::assertSentTo(
+            $user,
+            VerifyEmailChange::class,
+            function (VerifyEmailChange $notification, array $channels, $notifiable) {
+                return $notification->isNewUser === false
+                    && $notifiable->routeNotificationForMail($notification) === 'jane@example.com';
+            }
+        );
+    }
+
+    public function test_banner_resend_during_pending_change_routes_to_new_address(): void
+    {
+        Notification::fake();
+
+        // Unverified user (e.g. registered with a typo) who has since requested an email
+        // change — pending_email is set but email is still unverified, so the global
+        // verification banner shows.
+        $user = User::factory()->create([
+            'email' => 'old@example.com',
+            'pending_email' => 'new@example.com',
+            'email_verified_at' => null,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(EmailVerificationBanner::class)
+            ->call('resendVerification');
+
+        // The banner's resend must behave like a change-verification (isNewUser: false)
+        // and route to the NEW address — not hardcode isNewUser: true and misdeliver the
+        // link to the old/unreachable address.
+        Notification::assertSentTo(
+            $user,
+            VerifyEmailChange::class,
+            function (VerifyEmailChange $notification, array $channels, $notifiable) {
+                return $notification->isNewUser === false
+                    && $notifiable->routeNotificationForMail($notification) === 'new@example.com';
+            }
+        );
     }
 
     public function test_clicking_email_change_verification_link_updates_email(): void

--- a/tests/Feature/MailVolumeMonitorTest.php
+++ b/tests/Feature/MailVolumeMonitorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class MailVolumeMonitorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_warning_fires_once_when_daily_volume_crosses_threshold(): void
+    {
+        $warnings = [];
+        Event::listen(MessageLogged::class, function (MessageLogged $event) use (&$warnings) {
+            if (($event->context['event'] ?? null) === 'mail_volume_warning') {
+                $warnings[] = $event->context;
+            }
+        });
+
+        // Seed the day's counter to one below the warn threshold (80).
+        $key = 'mail-sent-count:'.now()->toDateString();
+        Cache::put($key, 79, now()->endOfDay());
+
+        // Two real sends (allowlisted domain, so MessageSent actually fires): the first
+        // crosses 80 and warns; the second (81) must NOT warn again the same day.
+        for ($i = 0; $i < 2; $i++) {
+            Mail::raw('ping', fn ($message) => $message->to('monitor@resend.dev')->subject('volume test'));
+        }
+
+        $this->assertCount(1, $warnings);
+        $this->assertSame(80, $warnings[0]['sent_today']);
+    }
+
+    public function test_no_warning_below_threshold(): void
+    {
+        $warnings = [];
+        Event::listen(MessageLogged::class, function (MessageLogged $event) use (&$warnings) {
+            if (($event->context['event'] ?? null) === 'mail_volume_warning') {
+                $warnings[] = $event->context;
+            }
+        });
+
+        Mail::raw('ping', fn ($message) => $message->to('monitor@resend.dev')->subject('volume test'));
+
+        $this->assertCount(0, $warnings);
+    }
+}

--- a/tests/Feature/PruneExpiredCacheTest.php
+++ b/tests/Feature/PruneExpiredCacheTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class PruneExpiredCacheTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_deletes_only_expired_rows(): void
+    {
+        config(['cache.default' => 'database']);
+
+        DB::table('cache')->insert([
+            ['key' => 'live', 'value' => 'x', 'expiration' => now()->addHour()->getTimestamp()],
+            ['key' => 'dead', 'value' => 'x', 'expiration' => now()->subHour()->getTimestamp()],
+        ]);
+
+        $this->artisan('cache:prune-expired')->assertSuccessful();
+
+        $this->assertDatabaseHas('cache', ['key' => 'live']);
+        $this->assertDatabaseMissing('cache', ['key' => 'dead']);
+    }
+
+    public function test_it_is_a_noop_when_cache_store_is_not_database(): void
+    {
+        config(['cache.default' => 'array']);
+
+        DB::table('cache')->insert([
+            ['key' => 'dead', 'value' => 'x', 'expiration' => now()->subHour()->getTimestamp()],
+        ]);
+
+        $this->artisan('cache:prune-expired')->assertSuccessful();
+
+        // Untouched: the command only prunes when the database store is active.
+        $this->assertDatabaseHas('cache', ['key' => 'dead']);
+    }
+}


### PR DESCRIPTION
## Summary

Finalizes the real-client-IP / auth-hardening branch and applies the fixes from a full branch review. The three feature commits already on the branch add: nginx real-client-IP resolution via `CF-Connecting-IP`, non-production privacy (basic-auth gate + noindex), and per-IP/per-account auth rate-limiting with security logging. This PR's new commit layers correctness fixes, refactors, and tests on top.

## Correctness fixes (from review)

- **Email-change verification routing** — the persistent verification banner's resend hardcoded `isNewUser: true`, misrouting the change link to the old/unreachable address (and invalidating the correctly-routed token). Now passes `! pending_email`, matching `ProfileForm`.
- **Staging HTTPS** — `forceScheme('https')` ran only in `production`, so `APP_ENV=staging` (behind upstream TLS) emitted `http://` form actions that browsers mixed-content-block. Now forced on every deployed env (`! local/testing`).
- **Login lockout time** — the retry message maxed `availableIn` over both limiters, reporting the 15-min per-IP window for a 1-min per-email lockout. Now computed from only the tripped limiter(s).
- **Mail-volume monitor** — replaced the non-atomic `has/put/increment` + strict `=== 80` with `Cache::add` + a `>=` threshold + a once-per-day guard, so a startup race or cache flush can't silently skip the alert.
- **Reset per-IP fairness** — the forgot-password cap counted every request (incl. broker-throttled/invalid), letting one user lock out neighbours on a shared IP. Now charged only when mail is actually sent.
- **Rate-limit key collision** — login keys embedded the raw email; `RateLimiter`'s entity-stripping aliased `josé@x.com` onto `jose@x.com`. The email component is now hashed.

## Refactors

- `App\Support\SecurityLog` — injects `ip`/`user_agent`/`request_id` once and drops the manual `timestamp` (duplicated Monolog's `datetime`); replaces ~14 copy-pasted context arrays and fixes field drift.
- `App\Support\IpRateLimiter` + `ThrottlesByIp` — shared throttle key/response plumbing for the auth flows.
- `FlashPolicy` update/delete deduped into `ownsOrLogDenied`.
- `cache:prune-expired` command (scheduled daily) — expired database-cache rows are otherwise only evicted lazily and get copied into every backup.
- Noindex middleware appended ahead of basic auth so 401 challenges also carry `X-Robots-Tag`.

## Docs

- CLAUDE.md / README corrected to name **nginx realip + `CF-Connecting-IP`** as the real-client-IP owner (enforced by the CF-only firewall rule); `trustProxies`/`TRUSTED_PROXY_IP` documented as inert defense-in-depth.

## Testing

`vendor/bin/pint --test` ✓ · `phpstan` (level 5) ✓ · **447 tests / 2065 assertions passing**. New tests: banner routing, login lockout message + per-IP backstop, mail-volume one-shot, reset per-IP fairness, cache pruning, and the HTTPS-exclusion guard.

## Notes / judgment calls

- **Enumeration trade-off (reset cap):** counting only actual sends means invalid-email probes are no longer IP-capped by this counter (the per-email broker throttle and `password_reset_invalid_user` logging still apply). Easy to revert to count-all if enumeration capping is preferred.
- A review finding about IP spoofing on a non-Cloudflare path was **not** actioned: pfSense admits only Cloudflare IPs, so there's no reachable non-CF path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)