### PR TITLE
Release: Cloudflare edge maintenance Worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ ASSET_URL=/
 # Staging / dev (e.g. dev.gotflashes.com): set APP_ENV=staging, APP_DEBUG=false, a NEW APP_KEY,
 # a SEPARATE DB_DATABASE, MAIL_MAILER=log, and BASIC_AUTH_* credentials. APP_ENV=staging engages
 # the noindex header + basic-auth gate + non-production mail allowlist automatically.
-# Full delta: DOCKER.md ("Staging / dev environment").
+# Full delta: docs/deployment.md ("Staging / dev environment").
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/README.md
+++ b/README.md
@@ -192,9 +192,10 @@ docker run -d --name gotflashes --restart unless-stopped \
   gotflashes:latest
 ```
 
-See **[DOCKER.md](DOCKER.md)** for complete Docker deployment guide including:
+See **[docs/deployment.md](docs/deployment.md)** for the complete deployment & operations guide including:
 - Quick start guide
 - Production deployment behind HAProxy
+- Cloudflare edge maintenance Worker
 - Management commands
 - Troubleshooting
 
@@ -294,9 +295,11 @@ gotflashes/
 ├── docker/                  # Docker-specific files
 ├── docs/
 │   ├── prd.md              # Product Requirements Document
+│   ├── deployment.md       # Deployment & operations (Docker, staging, Cloudflare edge)
 │   ├── membership-year-end-logic.md  # Year-specific membership system
 │   ├── CONTRIBUTING.md     # Contribution guidelines
 │   └── admin-awards-*.md   # Admin dashboard plans
+├── workers/                # Cloudflare edge maintenance-page Worker
 ├── public/                  # Web server document root
 │   ├── images/             # Award badges, logo, burgee
 │   └── build/              # Compiled assets (via Vite)
@@ -329,6 +332,7 @@ gotflashes/
 ## Documentation
 
 - **[Product Requirements](docs/prd.md)**: Detailed feature specifications and business rules
+- **[Deployment & Operations](docs/deployment.md)**: Docker, staging environments, and the Cloudflare edge maintenance Worker
 - **[Year-Specific Membership Logic](docs/membership-year-end-logic.md)**: Per-year district/fleet membership system with carry-forward
 - **[Contributing](docs/CONTRIBUTING.md)**: Guidelines for contributing to the project
 
@@ -390,6 +394,7 @@ Logs are written to `storage/logs/`. During development, view real-time logs wit
 ### Deployment Stack
 
 - **Cloudflare**: DNS, CDN, and Email Routing (firewall restricts traffic to Cloudflare IPs only)
+- **Cloudflare Worker**: Serves a branded maintenance page from the edge during origin outages (`workers/`; see [docs/deployment.md](docs/deployment.md))
 - **Resend**: Transactional email delivery (password resets, award notifications)
 - **ACME/Let's Encrypt**: SSL certificate management
 - **HAProxy**: SSL termination and reverse proxy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,7 @@
-# Docker Deployment
+# Deployment & Operations
 
-Operational guide for deploying and managing G.O.T. Flashes with Docker.
+Operational guide for deploying and managing G.O.T. Flashes: the Docker container, staging
+environments, and the Cloudflare edge in front of it.
 
 ## Configuration
 
@@ -115,3 +116,80 @@ docker exec -it gotflashes sh
 - Mounting `./database` would overwrite the container's migrations folder
 - Using a `data` subdirectory keeps database files persistent while preserving migrations in the container
 - SQLite WAL files (`.sqlite-wal`, `.sqlite-shm`) automatically persist alongside the main database file
+
+## Cloudflare Maintenance Worker
+
+A Cloudflare Worker (`workers/worker.js`, deployed via `workers/wrangler.toml`) serves a branded
+"Careening the Hull" maintenance page from Cloudflare's edge when the origin is unreachable, so
+users see an on-brand `503` instead of Cloudflare's raw error screen. We're on Cloudflare's
+**Free plan**, where the paid Error Pages / Custom Errors features aren't available, so a Worker
+is the only option; at ~1% of the free Workers request limit it costs nothing. The full design
+rationale lives in the `workers/worker.js` comments — the essentials below are the parts that
+live *outside* the repo (dashboard config and homelab-topology facts).
+
+**What triggers the page** (everything else passes through untouched):
+- **Origin fully unreachable** (pfSense/host reboot) — Cloudflare resolves the Worker's `fetch()`
+  with a `520`–`526`/`530` status (it does *not* throw), which the Worker matches.
+- **Gateway error, no live backend** (docker reset, or PHP-FPM dead while nginx is up) —
+  HAProxy/nginx return `502`/`503`/`504`.
+- **Application errors are never masked:** `500`/`501` (real Laravel bugs) and all `2xx`/`3xx`/`4xx`
+  pass straight through. Laravel's own `artisan down` returns `503`, which correctly shows the page.
+
+**Pre-ship check — do this *before* the Worker is live.** The `{502, 503, 504}` gateway subset assumes
+HAProxy returns `503` when its backend is gone. Confirm by taking the **app container/pod** down and
+leaving **HAProxy up** (killing HAProxy instead would exercise the deterministic `52x` origin-down path,
+*not* the uncertain gateway code you're checking), then `curl -I https://gotflashes.com`. Timing matters:
+run it *before* deploying the Worker — once live, the Worker returns its own `503` and masks HAProxy's
+real status (post-deploy you'd have to curl the origin directly, bypassing Cloudflare). The `52x`/`530`
+codes need no check; Cloudflare generates them itself. **Confirmed `503` on 2026-07-17** — revisit only
+if HAProxy's error handling changes.
+
+**Routes (`wrangler.toml`) — both hostnames:**
+```toml
+routes = [
+  { pattern = "gotflashes.com/*", zone_name = "gotflashes.com" },
+  { pattern = "www.gotflashes.com/*", zone_name = "gotflashes.com" }
+]
+```
+The `www` route is **load-bearing**: the `www → apex` redirect is done by **HAProxy on pfSense**
+(`redirect prefix … regsub(^www\.,,i) code 301`), *not* at the Cloudflare edge. When the origin is
+down that redirect can't fire, so without its own route a `www.` visitor would get Cloudflare's raw
+error page. (Aside: that HAProxy rule redirects to `http://`, so a healthy `www.` load takes an
+extra hop through Cloudflare's Always-Use-HTTPS; switching the rule to `https://` would save a
+round-trip — pfSense config, not this repo.)
+
+**Fail Open — manual dashboard step, NOT in `wrangler.toml`:** after deploying, set **both** routes'
+failure mode to **Fail open** (Workers & Pages → Settings → Domains & Routes → each route → Failure
+mode). Then if the Worker ever can't run (e.g. request limit hit), requests bypass it to origin —
+users see the normal site rather than Cloudflare's 1027 error. This Worker is a convenience layer,
+so a Worker outage should degrade to "normal site," never "site broken."
+
+**Deploying (first-time sequence):**
+1. **Pre-ship check** (above) — confirm HAProxy's no-backend status *before* anything goes live.
+2. `npx wrangler login` — one-time, interactive; opens a browser to authorize against the Cloudflare
+   account holding the `gotflashes.com` zone. (In a Claude Code session, run it as `! npx wrangler login`.)
+3. `cd workers && npx wrangler deploy` — uploads the Worker and binds both routes; live at the edge
+   within seconds, in front of all production traffic.
+4. **Set Fail open on both routes** (above) — `wrangler` can't do this; it's the one manual dashboard step.
+5. **Verify** (below).
+
+Redeploys are just step 3 (the routes and Fail-open setting persist). Confirm the account first with
+`npx wrangler whoami`.
+
+**Rollback:** remove the Worker route(s) (`wrangler delete` or the dashboard) → traffic goes straight
+to origin, exactly as before. The Worker holds no persistent state, so removal is instant.
+
+**Verify after deploy:**
+1. Normal site loads unchanged with the Worker active — homepage `200`, `/up` `200`, and `www.` still
+   `301`s to the apex (pass-through).
+2. A forced Laravel `500` (temporary throwing route) comes through — **not** the maintenance page.
+3. `docker stop` the app container (HAProxy up) → Careening page at `503`; `docker start` → site returns.
+4. During a full origin outage, `www.gotflashes.com` shows the page (proves the `www` route answers
+   directly, since the HAProxy redirect can't fire).
+5. During an outage, a `.js`/XHR request (`Sec-Fetch-Mode: cors`) gets a bare `503`, while a browser
+   navigation gets the HTML page. Confirm headers: `503`, `Retry-After: 120`, `Cache-Control: no-store`.
+
+> **Outage alerting** is intentionally *not* built in — the page tells visitors to email
+> `admin@gotflashes.com` rather than claiming automated notification. Adding an uptime monitor on
+> `/up` is tracked in [issue #47](https://github.com/johnhringiv/gotflashes/issues/47); the honest
+> `503` status makes the site outage-detectable by such a monitor.

--- a/workers/worker.js
+++ b/workers/worker.js
@@ -1,0 +1,130 @@
+// Cloudflare Worker: branded maintenance page for infrastructure outages.
+// Operations & deployment: docs/deployment.md ("Cloudflare Maintenance Worker").
+
+// Statuses that mean "infrastructure is down", NOT an app bug.
+//
+// 502/503/504 — gateway errors from our own stack: HAProxy with no live
+//   backend (docker reset), or nginx with PHP-FPM dead. Laravel's
+//   `artisan down` also emits 503, which genuinely is maintenance.
+//   Real app bugs surface as 500/501 and are deliberately NOT matched.
+//
+// 520-526/530 — Cloudflare-generated origin errors. When the origin is
+//   fully unreachable (pfSense/host reboot), the Worker's fetch() does
+//   NOT throw — Cloudflare resolves it with its own error response:
+//   521 (connection refused), 522 (timeout), 523 (unreachable),
+//   525/526 (origin TLS), 520/524/530 (misc origin failures). These are
+//   never emitted by Laravel or HAProxy, so matching them can't mask a bug.
+const MAINTENANCE_STATUSES = new Set([502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 530]);
+
+export default {
+    async fetch(request) {
+        let resp;
+        try {
+            resp = await fetch(request);
+        } catch {
+            // Belt-and-suspenders: most origin failures come back as 52x
+            // responses (handled below), but the runtime can still throw
+            // on internal errors.
+            return maintenance(request);
+        }
+
+        if (MAINTENANCE_STATUSES.has(resp.status)) {
+            return maintenance(request);
+        }
+
+        // Everything else — including genuine app 500s — passes through untouched.
+        return resp;
+    },
+};
+
+function maintenance(request) {
+    // Cosmetic gate: browser navigations get the full HTML page; failed
+    // assets/XHR get a bare 503 (no point shipping an HTML document as the
+    // body of a .js/.css/Livewire-update request).
+    if (!isPageRequest(request)) {
+        return new Response('Service Unavailable', {
+            status: 503,
+            headers: {
+                'retry-after': '120',
+                'cache-control': 'no-store',
+            },
+        });
+    }
+    return new Response(MAINTENANCE_HTML, {
+        status: 503,
+        headers: {
+            'content-type': 'text/html; charset=utf-8',
+            'retry-after': '120',
+            'cache-control': 'no-store',
+        },
+    });
+}
+
+// A "page" is a browser navigation (address bar, link click, form submit).
+// All current browsers send Sec-Fetch-Mode: navigations are "navigate";
+// assets and XHR/fetch — including Livewire's hashed update endpoint — are
+// "cors"/"no-cors". Clients that omit the header (curl, uptime monitors)
+// fall back to the Accept header.
+function isPageRequest(request) {
+    const mode = request.headers.get('sec-fetch-mode');
+    if (mode) {
+        return mode === 'navigate';
+    }
+    return (request.headers.get('accept') || '').includes('text/html');
+}
+
+const MAINTENANCE_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Careening the Hull — G.O.T. Flashes</title>
+  <style>
+    :root {
+      /* Lightning Class brand colors — matches the app theme in resources/css/app.css:
+         primary oklch(38% 0.09 245deg) = #2a588c, secondary is the lighter tooltip blue. */
+      --lightning-blue: #2a588c;
+      --lightning-blue-light: #3d74ac;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      color: #fff;
+      background: linear-gradient(160deg, var(--lightning-blue) 0%, var(--lightning-blue-light) 100%);
+      padding: 1.5rem;
+    }
+    .card { max-width: 32rem; text-align: center; }
+    .glyph {
+      width: 6rem;
+      height: 6rem;
+      margin: 0 auto 1.25rem;
+      display: grid;
+      place-items: center;
+      background: #fff;
+      border-radius: 50%;
+      box-shadow: 0 4px 16px rgb(0 0 0 / 25%);
+    }
+    .glyph img { height: 3.5rem; }
+    h1 { font-size: 1.9rem; margin: 0 0 0.75rem; }
+    p { font-size: 1.05rem; line-height: 1.6; opacity: 0.92; margin: 0.5rem 0; }
+    .small { font-size: 0.9rem; opacity: 0.7; margin-top: 1.5rem; }
+    .small a { color: #fff; font-weight: 600; text-underline-offset: 3px; }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <div class="glyph"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFQAAAC/CAYAAABg6PuAAAAGRklEQVR4Xu2dwXXbPBCEc4+l50siH1NCSkgJKSEluIS/g5SQElCCSkgJLEElOAII52cAUCIoLGYxwLw3l8i2zA0Ffjtcwh8+DCVlPn38aj4ffoX/PrRD5uXpmzkdLubl+Uv42lCmzMvhx7WYb+bl+F/42lCmzOn46oppz87n5+fw9aEM2fXSF/PNnqXh60MZ+qeYp8MUvj60UfZjfS2gWRTzzV6Qwq8b2qC5mMff/xTzdDiHXze0QSvFfBuYtEMO2K/rZFTMAfH58sW8RMUcmJSvG8UcEJ+rv91P2gOTcnSnmHbt/B5+z9CKFq3kmgcmbVXQ/aR9XVfD7xtKaFMxBybdl28lz1HxYo+s855Wu5+UBybdVlYxbZc0IH5dN4E95ZF1riu7mAOT1mWBPLOYI+tc093uJ+WBSWntKqb1wKRY5vT0MyrUFg9MirWp+0l7ZJ1LOcbcX8yBSUtlAnvCx9/hz+xWjxfzMDDpXas30vJswp/bpXZ0P2kPTNrZ/aQ8MOkBYI89MKlgMQcmPcSYkTvHpLLFPPSLSRn3fnLcJyYVAfaUe8Qke9AyxewQk4oBe+z+MOnvcz9xMR53b5hUlDEjd4ZJssU89IVJxRkzdj+YVKGYfWCSELDH7gGTxIA9Nj8mzYxZpZj8mCQI7ClzzyYVS9i3mhmTxBkzNPNskr3KRgcsa94R7iqMGZoRkzxjmuhg5c33pFtFxkz5TPU8UaEpjgK+/ofaC2HLUF+ZMbf64tbx1i5SHou0FTP0uYnOqTpjPu6Lm27WeNZCsKisz7aDC4+ruoBYJOXJNSCIsxaMRTVsqp21erCoiie3KYEkes1vEr0xvx16CaVX81Wd+iN/y5PYWesGEtq/yu/13DBItLnzDJJ7ak072AtZqM11V/8Z8qf4TbuwXJvr55OYODXTTz/DmhRRt8uBxNq6VFfLQe07BuTLAe7WNeFyoOPmIM1yUKv/z1Gzy4H2OYDGloN2NsvyUeGr+6XjA9FhaUSSkp+NOkcHhHRtRJKQWw50hDI4RCotwLxUaB2IVEL+rkF4gHWtEZH2yN8cnKIDrGntiJSj3buFlXM7iHRPHvrDA6zrVhEplP+oYyGfAZHeZeDtKNFzogpmp4gQyfX06I96AxN7W2XwrSbPQ7c+FAkPsKaJEElDNyQ1eoMQfNSHCpHgwQcVIsG7ISJE0hB8UCESPjQmQqT59kZ4gDVNhEgqgg8qREIHH0KTcgjhuyEqRIIHHxeawNjKwIOP42v4OzUrfDfEhEj44INrcyx88EGFSOjbwEyIBA8+mBAJH3zQIRK4G2JCJHzwQYRI+OCDDZHA3RDL2KEVPvigQiR08HFtHrg+6uBuyO1yI/AMO0IKgo/Q9Xa5KS0FwcctX1zr2wrgK+iGMmyXJKHNWEoJH3zstr4lAR98FLGOJUFBNyThyS0JiLEcAw8+xG2qjegoCD5qWm7zKyt8NwT1VHxJUPB0hha7rYiLIJg7S+fOqNczdWm/s1ihm4D+jD0n3qhHl9sxt7H9Qmq4zJLg+NSdtfDkSYvnJaFEV+ZCE/yEsiZPRQLwuatSvstNNRco6FLNbnpVxIJDFwv0muI3pnS9R3dU7s1U2iUuSrmiRS8NG8DwoJeyO7EL9GrxrNU7rPZ/w9DSRayRYbVG/jhBe8Nq81mrEr3af+TRo5eOhkHrurlH8DsKTLtCWIHnBHj2FrUCzwmQDfmi5wRK3QLRIgO9IBWO5NDCTk0LRnII+VFK1Ee9XiRXS9AABRHJSQqKSBoiuZLCIpKySO5RwRGJqbW0MlBEaiSS2yosIjUYyd0S+GmT9iO5pfywBA6R+FpLICLRRXLYEXSySA6LSFyRnJVBTpTwtZZIRGKL5KCIxBbJYRGJMZJDIlKlp+dqCYpIfJEc8p46WSRnZZCIRBfJQfcsYYvkoIjEFsnNreWUONAaJmwtkXOedJEcEpHoIjkoIpFFclb2oBIHWsOErSVyfIYtknsXpqhkkVyouqkSWSR3SxXQSe8DWFISTefZIrmt8gNgZddVtkguV/PFqti6yjXtsVe+v398IKy3dfOeHrsVQhbJlZJ/Ajl3XeWK5Eorswngi+QktLkJYIvkpHWzCWCL5Gop3QR01FpKKGgC+CI5hOaQ+rquNhbJ/QFJpzS1DAfR5wAAAABJRU5ErkJggg==" alt="Lightning Class logo"></div>
+    <h1>Careening the Hull</h1>
+    <p>We've hauled <strong>G.O.T. Flashes</strong> out of the water to scrub the hull and
+       tighten the rigging.</p>
+    <p>We'll be back off the dock and on the water in just a few minutes. Trim your sheets and
+       check back shortly.</p>
+    <p class="small">If this hangs around longer than a fair-weather race, hail the crew:
+       <a href="mailto:admin@gotflashes.com">admin@gotflashes.com</a></p>
+  </main>
+</body>
+</html>`;

--- a/workers/wrangler.toml
+++ b/workers/wrangler.toml
@@ -1,0 +1,8 @@
+name = "gotflashes-maintenance"
+main = "worker.js"
+compatibility_date = "2026-07-16"
+
+routes = [
+  { pattern = "gotflashes.com/*", zone_name = "gotflashes.com" },
+  { pattern = "www.gotflashes.com/*", zone_name = "gotflashes.com" }
+]


### PR DESCRIPTION
Release of the Cloudflare edge maintenance Worker (squash-merged as #49) from `develop` to `main`.

### Added
- **Cloudflare edge maintenance Worker** — serves a branded "Careening the Hull" `503` page from Cloudflare's edge when the origin is unreachable, so visitors get an on-brand page instead of Cloudflare's raw error screen. Triggers only on infrastructure failures — gateway codes (`502`/`503`/`504`) and Cloudflare origin-down codes (`520`–`526`/`530`) — and passes application errors (`500`/`501`) and all normal traffic through untouched. Routes both the apex and `www` (the `www → apex` redirect is done by HAProxy, so during a full outage the `www` route must answer the page directly).

### Changed
- Renamed `DOCKER.md` → **`docs/deployment.md`** ("Deployment & Operations") and added a **Cloudflare Maintenance Worker** section (trigger logic, routes, Fail Open, ordered deploy sequence, verify, rollback). Updated `README.md` (deployment stack + docs index) and `.env.example` references.

### Technical
- New `workers/worker.js` and `workers/wrangler.toml`. Page vs asset/XHR is classified by `Sec-Fetch-Mode` (with an `Accept` fallback), which avoids hardcoding Livewire's hashed `update` endpoint. Deployed as `503` + `Retry-After: 120` + `Cache-Control: no-store`.
- Worker is already live in production; this release version-controls the source and docs.

Follow-ups tracked separately: #47 (uptime monitor on `/up`), #48 (recently-active users for safer deploys).