### PR TITLE
feat: continuous deploy pipeline (CI → GHCR → host poller)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,6 +67,9 @@ jobs:
           context: .
           load: true # export to the local daemon for the smoke test below
           tags: gotflashes:ci
+          # The monthly scheduled run exists to pick up base-image/apk CVE
+          # fixes; served from cache it would no-op, so bypass cache then.
+          no-cache: ${{ github.event_name == 'schedule' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -129,5 +132,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          no-cache: ${{ github.event_name == 'schedule' }} # monthly CVE rebuild must not be served from cache
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -25,7 +25,7 @@ jobs:
           coverage: none
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true # public/ images + favicon are Git LFS; the image needs real content, not pointers
 
@@ -90,19 +90,19 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true # LFS images must be real content in the published image — same as the docker job
 
-      - uses: docker/setup-buildx-action@v3 # container driver; required for the gha build cache below
+      - uses: docker/setup-buildx-action@v4 # container driver; required for the gha build cache below
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
@@ -113,7 +113,7 @@ jobs:
             type=sha
             type=ref,event=tag
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,8 +3,11 @@ name: Code Quality
 on:
   push:
     branches: [ main, develop ]
+    tags: [ 'v*' ] # a release tag publishes a matching image tag (v1 → :v1)
   pull_request:
     branches: [ main, develop ]
+  schedule:
+    - cron: '26 4 4 * *' # monthly rebuild so the image picks up base-image CVE fixes
 
 jobs:
   check:
@@ -44,3 +47,77 @@ jobs:
 
       - name: Run all code quality checks
         run: composer check
+
+  docker:
+    name: Docker Build & Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true # public/ images + favicon are Git LFS; the image needs real content, not pointers
+
+      - name: Build image
+        run: docker build -t gotflashes:ci .
+
+      # Boot the container (entrypoint runs migrations + optimize) and check the
+      # /up health endpoint plus a real page render.
+      - name: Smoke test
+        run: |
+          docker run -d --name gotflashes-ci -p 8080:8080 \
+            -e APP_KEY="base64:$(openssl rand -base64 32)" \
+            gotflashes:ci
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8080/up >/dev/null && break
+            sleep 2
+          done
+          curl -sf http://localhost:8080/up >/dev/null || { docker logs gotflashes-ci; exit 1; }
+          curl -sf http://localhost:8080/ >/dev/null || { docker logs gotflashes-ci; exit 1; }
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f gotflashes-ci || true
+
+  # Publishes to GHCR on push to main (and v* tags); the production host polls
+  # :latest and redeploys when the digest changes — see deploy/README.md.
+  publish:
+    name: Publish Image to GHCR
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && (github.event_name == 'push' || github.event_name == 'schedule')
+    needs: [ check, docker ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true # LFS images must be real content in the published image — same as the docker job
+
+      - uses: docker/setup-buildx-action@v3 # container driver; required for the gha build cache below
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # :latest = newest main (what the host deploys); :sha-<commit> to pin a
+          # rollback; a git tag v1 publishes :v1 verbatim
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+            type=ref,event=tag
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,8 +57,18 @@ jobs:
         with:
           lfs: true # public/ images + favicon are Git LFS; the image needs real content, not pointers
 
+      - uses: docker/setup-buildx-action@v4 # container driver; required for the gha build cache below
+
+      # Shares the GHA build cache with the publish job, so a push to main
+      # doesn't pay for two cold multi-stage builds back-to-back.
       - name: Build image
-        run: docker build -t gotflashes:ci .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true # export to the local daemon for the smoke test below
+          tags: gotflashes:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Boot the container (entrypoint runs migrations + optimize) and check the
       # /up health endpoint plus a real page render.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
           - 8888:8888
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -27,7 +27,7 @@ jobs:
           coverage: pcov
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -39,7 +39,7 @@ jobs:
         run: npm ci
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -72,7 +72,7 @@ jobs:
           HTML_VALIDATOR_URL: http://localhost:8888
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-phpunit.xml,./coverage-browser.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .env.production
 *.sqlite
 *.sqlite-journal
+# Host deploy config holds secrets; only the .example template is tracked
+deploy/*.env
 .phpactor.json
 .phpunit.result.cache
 /.fleet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,8 +267,18 @@ Routes in `routes/web.php`:
 
 ### GitHub Actions
 - Workflow: `.github/workflows/check.yml`
-- Runs on: push and PR to main/master/develop branches
-- Single job runs `composer check` (linting + tests)
+- Runs on: push and PR to main/develop, `v*` tags, and a monthly schedule
+- Jobs: `check` (composer check — linting + tests), `docker` (image build + `/up` smoke test), `publish` (GHCR push)
+- Docker jobs check out with `lfs: true` — `public/` images are Git LFS and must be real content in the image
+
+## Deployment
+
+Continuous deploy from `main` — full runbook in `deploy/README.md`, operations guide in `docs/deployment.md`:
+- CI publishes `ghcr.io/johnhringiv/gotflashes:latest` (+ `:sha-<commit>` per commit) on every push to `main`; a monthly rebuild picks up base-image CVE fixes
+- The production host (Synology, behind pfSense/Cloudflare, no inbound access) polls the tag every 5 minutes via `deploy/poll-deploy.sh` and redeploys on digest change; it also self-heals a stopped container and alerts (non-zero exit) when the edge is unreachable
+- `deploy/deploy.sh` replaces the single app container and health-gates on `/up` (the entrypoint runs migrations first); deploys are a brief outage covered by the Cloudflare maintenance Worker
+- Secrets + host settings live in a host-side env file (`deploy/gotflashes.env.example`); everything else is baked into the image from `docker/.env.docker`
+- SQLite DB, logs, and backups persist in `DATA_DIR` bind mounts; rollback = pin a `sha-…` tag on the host, then `git revert` on `main` to make it durable
 
 ## Observability
 

--- a/README.md
+++ b/README.md
@@ -174,26 +174,34 @@ Press `Ctrl+C` to exit Tinker.
 
 ### Docker Deployment
 
-For production deployment using Docker (no PHP/Node required on host):
+Production runs the image CI publishes to GHCR on every push to `main`
+(`ghcr.io/johnhringiv/gotflashes:latest`); the host polls and redeploys
+automatically — **continuous deploy from `main`**. See
+**[deploy/README.md](deploy/README.md)** for the full runbook (host setup,
+rollback, staging instance).
+
+To build and run the image locally (no PHP/Node required on host):
 
 ```bash
-# 1. Configure environment
-cp docker/.env.docker .env
-# Edit .env and set APP_KEY and RESEND_KEY
+# 1. Configure environment (secrets only; defaults are baked into the image)
+cp deploy/gotflashes.env.example gotflashes.env
+# Edit gotflashes.env: set APP_KEY and RESEND_KEY (this manual run mounts
+# repo-relative paths directly, so DATA_DIR can stay empty)
 
 # 2. Build and run
-mkdir -p database/data storage/app storage/logs
-docker build -t gotflashes:latest .
+docker build -t gotflashes:local .
+mkdir -p database/data storage/logs backups
 docker run -d --name gotflashes --restart unless-stopped \
-  -p 8080:80 \
+  -p 8080:8080 \
   -v $(pwd)/database/data:/var/www/html/database/data \
   -v $(pwd)/storage/logs:/var/www/html/storage/logs \
-  --env-file .env \
-  gotflashes:latest
+  -v $(pwd)/backups:/var/www/html/storage/app/backups \
+  --env-file gotflashes.env \
+  gotflashes:local
 ```
 
-See **[docs/deployment.md](docs/deployment.md)** for the complete deployment & operations guide including:
-- Quick start guide
+See **[docs/deployment.md](docs/deployment.md)** for the complete operations guide including:
+- Configuration and staging environments
 - Production deployment behind HAProxy
 - Cloudflare edge maintenance Worker
 - Management commands

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,203 @@
+# Deploy runbook: CI → GHCR → poll (continuous deploy from main)
+
+gotflashes ships as the self-contained Docker image built by
+[`Dockerfile`](../Dockerfile). Deploys are **pull-based**: the production host
+sits behind pfSense/Cloudflare with no inbound access, so CI publishes an
+image and the host polls for it. There is **no manual promote step** — every
+push to `main` that passes CI is live within one poll cycle. Since releases
+reach `main` only via deliberate `dev → main` merges (see
+[CONTRIBUTING](../docs/CONTRIBUTING.md)), merging to `main` *is* the release
+decision.
+
+```
+push to main ──► CI (quality checks + docker smoke) ──► GHCR :latest  (+ :sha-<commit>)
+                                                             │
+                            host cron: poll-deploy.sh ───────┘ pull :latest when digest changes
+                                             │
+                                             └─► deploy.sh: replace container, health-gate on /up
+```
+
+## Pipeline
+
+**CI** (`.github/workflows/check.yml`) runs on every push and PR: the full
+quality suite (`composer check`) plus a Docker job that builds the image and
+smoke-tests it (boot, migrate, `/up` 200, homepage 200). On push to `main`
+(or a `v*` tag) the publish job pushes to GHCR:
+
+- `ghcr.io/johnhringiv/gotflashes:latest` — newest main (**what the host deploys**)
+- `…:sha-<commit>` — every commit (pin one to roll back)
+- `…:v1` — a `v*` git tag, verbatim
+
+A monthly scheduled run rebuilds so the base image picks up CVE fixes. The
+checkouts that feed a Docker build use `lfs: true` — the award badges,
+favicon, and logo in `public/` are Git LFS, and without it the image would
+ship pointer files instead of images.
+
+Public repo → public image, so no registry auth is needed on the host.
+
+## What a deploy does (and the brief outage)
+
+The app is **one container**: its SQLite database can't be served by two app
+instances mid-migration, so there is no rolling pair here (unlike
+johnhringiv.com). `deploy.sh` stops the old container, starts the new one,
+and health-gates on `/up` — the entrypoint runs `php artisan migrate --force`
+before nginx serves, so the gate also proves migrations applied. The gap is
+the seconds-to-a-minute the new container needs to boot; during it the
+Cloudflare maintenance Worker serves the branded "Careening the Hull" 503
+(see `docs/deployment.md`), and HAProxy/Cloudflare pass traffic again the
+moment `/up` answers.
+
+Data persists across deploys via bind mounts under `DATA_DIR` (the existing
+prod layout — on the Synology, `/volume3/docker_ssd/gotflashes`):
+
+| Host path          | Container path                      | Holds                               |
+| ------------------ | ----------------------------------- | ----------------------------------- |
+| `$DATA_DIR/data`   | `/var/www/html/database/data`       | SQLite DB + WAL files               |
+| `$DATA_DIR/logs`   | `/var/www/html/storage/logs`        | app + nginx logs                    |
+| `$DATA_DIR/backup` | `/var/www/html/storage/app/backups` | daily DB backups (90-day retention) |
+
+## Host setup (one time)
+
+1. Copy `deploy.sh`, `poll-deploy.sh`, and `gotflashes.env.example` to a
+   directory on the host; `cp gotflashes.env.example gotflashes.env`, fill it
+   in (`chmod 600 gotflashes.env`). `DATA_DIR` must point at the existing
+   data directory — the one already holding `data/`, `logs/`, and `backup/`.
+2. First deploy by hand. On Synology/DSM the Docker socket is root-only, so
+   the scripts need `sudo`:
+   ```sh
+   sudo sh deploy.sh gotflashes.env
+   ```
+   Migrating from the old hand-run container? See
+   [Cutover from the hand-run container](#cutover-from-the-hand-run-container)
+   first.
+3. Schedule the poller every 5 minutes **as root** — on Synology via Task
+   Scheduler (below); on a generic host via cron:
+   ```
+   */5 * * * * cd /path/to/deploy && sh poll-deploy.sh gotflashes.env >> poll-deploy.log 2>&1
+   ```
+   Have cron/DSM notify you on a non-zero exit — the only time the poller
+   signals a problem.
+
+### Synology (DSM) Task Scheduler
+
+DSM overwrites the system crontab, so schedule the poller through the UI:
+
+1. **Control Panel → Task Scheduler → Create → Scheduled Task → User-defined
+   script**.
+2. **General**: name it (e.g. `gotflashes poll-deploy`); **User: `root`**
+   (Docker is root-only on DSM); Enabled.
+3. **Schedule**: Daily, First run `00:00`, **Frequency: Every 5 minutes**,
+   Last run `23:55`.
+4. **Task Settings → Run command → User-defined script**:
+   ```sh
+   cd /path/to/deploy_scripts/gotflashes && sh poll-deploy.sh gotflashes.env >> poll-deploy.log 2>&1
+   ```
+   Also tick **"Send run details by email … only when the script terminates
+   abnormally"** — `poll-deploy.sh` exits non-zero only on a real problem
+   (unhealthy deploy, or the edge unreachable), so this pages you exactly
+   then and stays quiet on the routine no-op cycles.
+5. Select the task → **Run** to fire it once; check `poll-deploy.log`.
+
+DSM gotchas: don't use `--cpus` (DSM kernels lack the CFS scheduler — the
+scripts don't); if you replace the container by hand, remove the old one
+first so the HAProxy backend port is free (`deploy.sh` only removes the
+container named in `CONTAINER`).
+
+## Cutover from the hand-run container
+
+One-time migration from the old dated container (`gotflashes-2026-1-1`,
+HAProxy backend `:8085`). The new container comes up on `:8087`, so both run
+side by side until HAProxy is switched — but they share `DATA_DIR`, so during
+the window:
+
+- the new container applies any **pending migrations to the live database**
+  the old container is still serving (fine for additive migrations, which is
+  the norm here — but it is one-way);
+- **both** queue workers poll the same `jobs` table and both schedulers run;
+- both append to the same log files.
+
+Keep the window short: verify, cut over, retire.
+
+1. `sudo sh deploy.sh gotflashes.env` — starts `gotflashes` on `:8087`
+   against the live data; the old container keeps serving `:8085`.
+2. Verify the new container directly: `curl http://localhost:8087/up`, click
+   around via the HAProxy stats page or an SSH tunnel if you want more than
+   the health check.
+3. Switch the HAProxy backend on pfSense from `:8085` to `:8087`; confirm the
+   edge (`curl https://gotflashes.com/up`).
+4. Retire the old container:
+   ```sh
+   sudo docker stop gotflashes-2026-1-1 && sudo docker rm gotflashes-2026-1-1
+   ```
+5. Now schedule the poller (Host setup step 3). Don't schedule it before the
+   cutover is done — its self-heal/redeploy logic manages only the new
+   container.
+
+## Continuous deploy loop
+
+`poll-deploy.sh`, run from the scheduler:
+
+- **Unchanged `:latest`, container running, edge healthy** → cheap no-op
+  (one manifest check + one `/up` probe through Cloudflare).
+- **Changed `:latest` digest** (a new push to `main` landed) → runs
+  `deploy.sh`, then verifies the edge; exits non-zero if it never comes up.
+- **Container not running on an unchanged tag** (e.g. after a host reboot,
+  before Docker's `restart unless-stopped` has settled) → self-heals by
+  redeploying.
+- **Container running but the edge unreachable** → exits non-zero *without*
+  redeploying (Cloudflare/HAProxy/DNS trouble a redeploy won't fix).
+
+## Rollback
+
+Immediate stopgap — on the host, pin the last-good build and redeploy:
+
+```sh
+sudo IMAGE=ghcr.io/johnhringiv/gotflashes:sha-<commit> sh deploy.sh gotflashes.env
+```
+
+Get the `sha-<commit>` from the CI run (or `git log`) of the good commit.
+
+**The pin is only a stopgap:** the poller watches `:latest`, so the next
+cycle re-pulls the bad build. For a durable rollback, also **`git revert` the
+bad commit on `main` and push** — CI republishes `:latest` as the fixed build
+and the poller converges on it. Pin first to stop the bleeding, then revert
+to make it stick.
+
+**Migrations caveat:** rolling back the image does not roll back the
+database. Migrations here are additive as a rule, so an old image on a newer
+schema is normally fine; if a bad release's migration was itself the problem,
+restore the pre-deploy backup from `$DATA_DIR/backups` (daily, 02:00) before
+pinning.
+
+## Offline / manual image (fallback)
+
+Build and `docker save` anywhere, copy the tarball to the host, and pass it
+as the second argument — the pull is skipped and the loaded image is used:
+
+```sh
+docker build -t gotflashes:local .
+docker save gotflashes:local | gzip > gotflashes.tar.gz
+# on the host:
+sudo IMAGE=gotflashes:local sh deploy.sh gotflashes.env gotflashes.tar.gz
+```
+
+This replaces the old `docker save` → copy `.img` → `docker load` →
+recreate-by-hand ritual for the cases where you still need it.
+
+## Staging instance (dev.gotflashes.com)
+
+Same scripts, second env file: `cp gotflashes.env.example gotflashes-dev.env`
+with a **different** `CONTAINER`, `PORT`, `DATA_DIR`, and `APP_KEY`, plus the
+staging deltas (`APP_ENV=staging`, `APP_URL`, basic auth, `MAIL_MAILER=log`)
+— rationale in `docs/deployment.md`. Run/schedule the poller with that env
+file as the argument. Staging normally tracks the same `:latest`; point its
+`IMAGE` at a `sha-…` tag to hold it on a specific build.
+
+## Verify
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' https://gotflashes.com/up   # 200
+curl -s https://gotflashes.com/ | grep -i 'G.O.T. Flashes'           # sanity-check a page
+sudo docker ps --filter name=gotflashes                              # container Up
+sudo docker exec gotflashes php artisan migrate:status | tail -3
+```

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Single-container deploy for gotflashes (no compose).
+#
+# Deploys the newest main build (:latest, published by CI on every push to
+# main). Secrets and host-specific settings live in an env file next to this
+# script (copy gotflashes.env.example and fill it in, chmod 600); everything
+# else is baked into the image (docker/.env.docker).
+#
+# Usage:
+#   sudo sh deploy.sh [env-file]                 # pull IMAGE and replace the container
+#   sudo sh deploy.sh [env-file] <image-tarball> # load a saved image instead of pulling (offline)
+#
+# The app runs as ONE container (its SQLite database can't be shared by two
+# instances mid-migration), so a deploy is a brief outage while the new
+# container boots and migrates — the Cloudflare maintenance Worker shows the
+# branded "Careening the Hull" page for those seconds. The new container is
+# health-gated on /up: if it never comes up, this script exits non-zero.
+#
+# Idempotent: re-running replaces the container; the database, logs, and
+# backups live in DATA_DIR bind mounts and persist across deploys.
+set -e
+
+ENV_FILE="${1:-gotflashes.env}"
+IMAGE_TAR="${2:-}"
+
+[ -f "$ENV_FILE" ] || { echo "missing $ENV_FILE (copy gotflashes.env.example and fill it in)"; exit 1; }
+
+env_get() {
+    grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2-
+}
+
+# Each setting: $VAR from the environment > VAR= line in the env file > default.
+# The env override enables one-offs, e.g. roll back with
+#   sudo IMAGE=ghcr.io/johnhringiv/gotflashes:sha-abc123 sh deploy.sh
+IMAGE="${IMAGE:-$(env_get IMAGE)}"
+IMAGE="${IMAGE:-ghcr.io/johnhringiv/gotflashes:latest}"
+CONTAINER="${CONTAINER:-$(env_get CONTAINER)}"
+CONTAINER="${CONTAINER:-gotflashes}"
+PORT="${PORT:-$(env_get PORT)}"
+PORT="${PORT:-8087}"   # HAProxy backend port
+DATA_DIR="${DATA_DIR:-$(env_get DATA_DIR)}"
+[ -n "$DATA_DIR" ] || { echo "DATA_DIR is not set in $ENV_FILE"; exit 1; }
+
+if [ -n "$IMAGE_TAR" ]; then
+    docker load -i "$IMAGE_TAR"
+else
+    docker pull "$IMAGE" || echo "pull failed; will use local image $IMAGE if present"
+fi
+
+# Persistent data lives on the host; the container runs as UID/GID 1000
+# (appuser), so newly created dirs must be chowned to it. Existing dirs are
+# left alone — they already carry live data with correct ownership.
+for d in "$DATA_DIR/data" "$DATA_DIR/logs" "$DATA_DIR/backup"; do
+    if [ ! -d "$d" ]; then
+        mkdir -p "$d"
+        chown 1000:1000 "$d"
+    fi
+done
+
+echo "$(date -u +%FT%TZ) recreating $CONTAINER on :$PORT from $IMAGE"
+# Graceful stop first (SIGTERM -> supervisord clean shutdown) so Synology's
+# Container Manager doesn't report a "stopped unexpectedly" (which a SIGKILL
+# from `rm -f` on a running container triggers). rm -f then just removes the
+# already-stopped container.
+docker stop "$CONTAINER" >/dev/null 2>&1 || true
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$CONTAINER" --restart unless-stopped \
+    `# no --cpus: DSM kernels lack the CFS scheduler` \
+    -p "$PORT:8080" \
+    -v "$DATA_DIR/data:/var/www/html/database/data" \
+    -v "$DATA_DIR/logs:/var/www/html/storage/logs" \
+    -v "$DATA_DIR/backup:/var/www/html/storage/app/backups" \
+    --env-file "$ENV_FILE" \
+    "$IMAGE" >/dev/null
+
+# Health-gate: the entrypoint runs migrations before nginx starts serving, so
+# give it up to ~2 min. /up is Laravel's health endpoint (basic-auth exempt).
+i=0
+while [ $i -lt 24 ]; do
+    if curl -sf -m 5 "http://localhost:$PORT/up" >/dev/null 2>&1; then
+        echo "$(date -u +%FT%TZ) $CONTAINER healthy on :$PORT"
+        docker image prune -f >/dev/null 2>&1 || true
+        docker ps --filter "name=$CONTAINER" --format '{{.Names}}: {{.Status}}'
+        echo "$(date -u +%FT%TZ) deployed $IMAGE"
+        PUBLIC_URL="${PUBLIC_URL:-$(env_get PUBLIC_URL)}"
+        [ -n "$PUBLIC_URL" ] && echo "verify: curl $PUBLIC_URL/up"
+        exit 0
+    fi
+    i=$((i + 1))
+    sleep 5
+done
+
+echo "$(date -u +%FT%TZ) FAILED: $CONTAINER did not become healthy on :$PORT"
+docker logs "$CONTAINER" 2>&1 | tail -20
+exit 1

--- a/deploy/gotflashes.env.example
+++ b/deploy/gotflashes.env.example
@@ -1,0 +1,40 @@
+# Host config for deploy.sh / poll-deploy.sh — copy to gotflashes.env next to
+# the scripts, fill in, chmod 600.
+#
+# This file is both the scripts' config AND the container's --env-file, so it
+# holds only host-specific settings and secrets; every other app setting is
+# baked into the image from docker/.env.docker. Docker's --env-file parser is
+# literal: NO quotes around values, no spaces around =.
+
+# --- Deploy settings (read by the scripts; harmless inside the container) ---
+IMAGE=ghcr.io/johnhringiv/gotflashes:latest
+CONTAINER=gotflashes
+# HAProxy backend port on the host (container always listens on 8080)
+PORT=8087
+# Edge URL the poller health-checks through Cloudflare
+PUBLIC_URL=https://gotflashes.com
+# Host directory holding the persistent bind mounts, laid out flat:
+# $DATA_DIR/data (SQLite), $DATA_DIR/logs, $DATA_DIR/backup.
+# On the Synology this is /volume3/docker_ssd/gotflashes (DSM's UI shows it
+# share-relative as /docker_ssd/gotflashes).
+DATA_DIR=
+
+# --- App secrets (required) ---
+# Generate: docker run --rm php:8.5-cli php -r "echo 'base64:' . base64_encode(random_bytes(32)) . PHP_EOL;"
+APP_KEY=
+# Resend API key for verification/notification mail
+RESEND_KEY=
+# HAProxy IP; inert defense-in-depth (see docs/deployment.md) but keep it set
+TRUSTED_PROXY_IP=
+# Grace-period anchor (also baked into the image; set to pin it explicitly)
+START_YEAR=2026
+
+# --- Staging instance only (dev.gotflashes.com) ---
+# Uncomment for a second container with its own env file; use a DIFFERENT
+# CONTAINER, PORT, DATA_DIR, and APP_KEY than production, and never point
+# DATA_DIR at production's. Full rationale: docs/deployment.md.
+#APP_ENV=staging
+#APP_URL=https://dev.gotflashes.com
+#MAIL_MAILER=log
+#BASIC_AUTH_USERNAME=
+#BASIC_AUTH_PASSWORD=

--- a/deploy/poll-deploy.sh
+++ b/deploy/poll-deploy.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Poll the deploy image tag and redeploy when its digest changes — and
+# self-heal: an unchanged tag with the container not running (typical after a
+# host reboot, before Docker's `restart unless-stopped` has settled) also
+# triggers a redeploy.
+#
+# Runs from a scheduler on the production host (Synology DSM Task Scheduler,
+# every 5 minutes, as root; elsewhere: cron). The host sits behind
+# pfSense/Cloudflare with no inbound access, so deploys are pull-based: CI
+# publishes to GHCR and this poller converges on it. An unchanged healthy tag
+# costs one manifest check and one edge /up probe; layers only download when
+# CI has published a new :latest, i.e. after a push to main. This is
+# continuous deploy from main.
+#
+#   sh poll-deploy.sh [env-file]
+#
+# Exit codes: 0 = no-op or successful deploy; 1 = unhealthy (a deploy ran but
+# the edge never came up, or the container is running yet the edge is
+# unreachable — Cloudflare/HAProxy/DNS trouble a redeploy wouldn't fix).
+# Configure the scheduler to notify on abnormal termination.
+set -e
+
+ENV_FILE="${1:-gotflashes.env}"
+DIR=$(dirname "$0")
+
+[ -f "$ENV_FILE" ] || { echo "missing $ENV_FILE"; exit 1; }
+
+env_get() {
+    grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2-
+}
+
+IMAGE="${IMAGE:-$(env_get IMAGE)}"
+IMAGE="${IMAGE:-ghcr.io/johnhringiv/gotflashes:latest}"
+CONTAINER="${CONTAINER:-$(env_get CONTAINER)}"
+CONTAINER="${CONTAINER:-gotflashes}"
+PUBLIC_URL="${PUBLIC_URL:-$(env_get PUBLIC_URL)}"
+
+container_running() {
+    [ "$(docker inspect "$1" --format '{{.State.Running}}' 2>/dev/null)" = "true" ]
+}
+
+# Three attempts, 5s apart — one blip shouldn't page or churn the container.
+edge_healthy() {
+    [ -n "$PUBLIC_URL" ] || return 0
+    i=0
+    while [ $i -lt 3 ]; do
+        curl -sf -m 5 "$PUBLIC_URL/up" >/dev/null 2>&1 && return 0
+        i=$((i + 1))
+        sleep 5
+    done
+    return 1
+}
+
+# Before CI's first publish the tag may not exist; that is not an error.
+if ! docker pull -q "$IMAGE" >/dev/null 2>&1; then
+    echo "$(date -u +%FT%TZ) pull failed for $IMAGE (tag not published yet?); skipping"
+    exit 0
+fi
+
+latest=$(docker image inspect "$IMAGE" --format '{{.Id}}')
+running=$(docker inspect "$CONTAINER" --format '{{.Image}}' 2>/dev/null || echo none)
+
+if [ "$latest" = "$running" ]; then
+    if container_running "$CONTAINER"; then
+        if edge_healthy; then
+            exit 0
+        fi
+        echo "$(date -u +%FT%TZ) UNHEALTHY: $CONTAINER running but ${PUBLIC_URL}/up unreachable (Cloudflare/HAProxy/DNS?); not redeploying"
+        exit 1
+    fi
+    echo "$(date -u +%FT%TZ) $CONTAINER not running on unchanged image (host rebooted?); redeploying"
+else
+    echo "$(date -u +%FT%TZ) new image for $IMAGE (running=$running -> $latest); deploying"
+fi
+
+# deploy.sh health-gates the new container on localhost:$PORT/up.
+sh "$DIR/deploy.sh" "$ENV_FILE"
+
+# Confirm the edge too (deploy.sh only checks localhost).
+if [ -n "$PUBLIC_URL" ]; then
+    if edge_healthy; then
+        echo "$(date -u +%FT%TZ) deploy healthy at edge"
+        exit 0
+    fi
+    echo "$(date -u +%FT%TZ) DEPLOY UNHEALTHY: ${PUBLIC_URL}/up not responding"
+    exit 1
+fi
+echo "$(date -u +%FT%TZ) deployed (no PUBLIC_URL; edge check skipped)"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,11 +3,16 @@ set -e
 
 echo "Starting G.O.T. Flashes application..."
 
-# Ensure database file exists if it doesn't already
-if [ ! -f /var/www/html/database/database.sqlite ]; then
-    echo "Creating SQLite database..."
-    touch /var/www/html/database/database.sqlite
-    chmod 664 /var/www/html/database/database.sqlite
+# Ensure the SQLite database file exists. DB_DATABASE is only in the shell
+# environment when passed at runtime (--env-file); the default must match the
+# baked .env (docker/.env.docker). In production the file already exists on
+# the bind mount, so this only fires on fresh/ephemeral runs (e.g. CI smoke).
+DB_FILE="${DB_DATABASE:-/var/www/html/database/data/database.sqlite}"
+if [ ! -f "$DB_FILE" ]; then
+    echo "Creating SQLite database at $DB_FILE..."
+    mkdir -p "$(dirname "$DB_FILE")"
+    touch "$DB_FILE"
+    chmod 664 "$DB_FILE"
 fi
 
 # Run migrations (includes reference data seeding)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,9 +3,17 @@
 Operational guide for deploying and managing G.O.T. Flashes: the Docker container, staging
 environments, and the Cloudflare edge in front of it.
 
+> **How code reaches production:** CI publishes the image to GHCR on every push to `main` and the
+> host polls and redeploys it automatically (continuous deploy from `main`). The pipeline, host
+> setup, and rollback procedure live in **[deploy/README.md](../deploy/README.md)** — this document
+> covers configuration, staging, day-to-day operations, and the Cloudflare edge.
+
 ## Configuration
 
-Most environment variables are pre-configured in `docker/.env.docker`. You only need to set:
+Most environment variables are pre-configured in `docker/.env.docker`, which is baked into the
+image as its `.env`. Host-specific settings and secrets live in an env file on the host
+(`deploy/gotflashes.env.example` is the template) that is passed to the container via
+`--env-file`; real environment variables take precedence over the baked `.env`. You only need to set:
 
 **Required:**
 - `APP_KEY` - Generate with: `docker run --rm php:8.2-cli php -r "echo 'base64:' . base64_encode(random_bytes(32)) . PHP_EOL;"`
@@ -61,21 +69,12 @@ The entrypoint automatically:
 
 ## Management Commands
 
-To Clear rebuild and run
-```bash
-docker stop gotflashes && docker rm gotflashes
-docker build -t gotflashes:latest .
-docker run -d --name gotflashes -p 8081:8080 \
-  -e DB_DATABASE=/var/www/html/database/data/database.sqlite \
-  -v $(pwd)/database/data:/var/www/html/database/data \
-  -v $(pwd)/storage/logs:/var/www/html/storage/logs \
-  -v $(pwd)/backups:/var/www/html/storage/app/backups \
-  --env-file .env gotflashes:latest
-```
+Deploying, rolling back, and the offline image-tarball fallback are all covered by the scripts in
+[`deploy/`](../deploy/README.md) — the manual stop/build/run and `docker save` ritual is retired.
+To force a redeploy of the current image on the host:
 
-To Save
 ```bash
-docker save -o gotflashes.img gotflashes:latest
+sudo sh deploy.sh gotflashes.env
 ```
 
 Misc
@@ -102,7 +101,7 @@ docker exec -it gotflashes sh
 
 ## Architecture
 
-- **Alpine Linux + PHP 8.4**: ~175MB image
+- **Alpine Linux + PHP 8.5**: ~175MB image
 - **Multi-stage build**: Node build → production image
 - **Supervisor**: Manages nginx, PHP-FPM, queue worker, scheduler
 - **SQLite**: Persisted via volume mounts


### PR DESCRIPTION
## Summary

Replaces the manual `docker save`/`docker load` deploy ritual with the pull-based continuous-deploy process already used by johnhringiv.com and notes-mcp: CI publishes the image to GHCR on every push to `main`, and the production host polls the tag and redeploys itself. Merging `dev → main` becomes the release decision; no manual promote step.

```
push to main ──► CI (quality checks + docker smoke) ──► GHCR :latest (+ :sha-<commit>)
                                                            │
                           host cron: poll-deploy.sh ───────┘ pull :latest when digest changes
                                            │
                                            └─► deploy.sh: replace container, health-gate on /up
```

## Changes

- **`.github/workflows/check.yml`** — new `docker` job (image build + smoke test: boot, migrate, `/up` and homepage 200) on every push/PR, and a `publish` job pushing `:latest` / `:sha-<commit>` / `:v*` to GHCR on `main`; monthly scheduled rebuild picks up base-image CVE fixes. Docker checkouts use `lfs: true` — the award badges/favicon are Git LFS and must be real content in the image, not pointers.
- **`deploy/deploy.sh`** — env-file-driven single-container deploy: pull → replace → health-gate on `/up` (the entrypoint runs migrations before nginx serves, so the gate also proves migrations applied). Persistent data stays on the existing flat `DATA_DIR` bind mounts (`data/`, `logs/`, `backup/`).
- **`deploy/poll-deploy.sh`** — 5-minute digest poll with host-reboot self-heal; exits non-zero only on a real problem (for scheduler email alerts), including "edge unreachable but container fine" without churning containers.
- **`deploy/gotflashes.env.example` + `deploy/README.md`** — host env template (secrets only; everything else is baked from `docker/.env.docker`) and the full runbook: Synology Task Scheduler setup, side-by-side :8087 cutover from the hand-run container, rollback via `sha-…` pin + `git revert`, offline tarball fallback, staging instance.
- **`docker/entrypoint.sh`** — DB-create path now honors `DB_DATABASE` (was touching the stale pre-`data/` location).
- Docs updated: `docs/deployment.md`, `README.md`, `CLAUDE.md`; `.gitignore` gains `deploy/*.env` so a filled-in host env file can never be committed.

## Verification

- Image built from this branch; the CI smoke test run locally passes (`/up` and homepage 200 on a fresh container, migrations clean).
- `deploy.sh`/`poll-deploy.sh` exercised end-to-end against a throwaway local registry: fresh deploy, digest-change redeploy, reboot self-heal, and healthy no-op all behave; SQLite data persisted across redeploys with the prod-matching flat mount layout.
- No secrets in the diff — env template fields are blank; the only key in CI is a randomly generated ephemeral one.

## Notes

- Deploys are a brief single-container outage (seconds) covered by the Cloudflare "Careening the Hull" maintenance Worker.
- First production deploy is a one-time side-by-side cutover on port 8087 while the current container keeps serving 8085 — sequence in `deploy/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)