### PR TITLE
Make Unaffiliated/None a real district and fleet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,11 +216,13 @@ Routes in `routes/web.php`:
 
 **districts table:**
 - Lightning Class districts for geographic organization
+- Includes the sentinel "Unaffiliated/None" district (`District::NONE_NAME`/`District::noneId()`) — a real row so member affiliations are never null; excluded from the district leaderboard
 - Used in leaderboard aggregation
 
 **fleets table:**
 - Lightning Class fleets (numbered)
 - Includes fleet_number and fleet_name
+- Includes the sentinel "None" fleet (`fleet_number` 0, `Fleet::NONE_NUMBER`/`Fleet::noneId()`), selectable alongside ANY district; excluded from the fleet leaderboard; display code renders `fleet_number ?: '—'`
 - Used in leaderboard aggregation
 
 **flashes table:**

--- a/app/Http/Controllers/Api/FleetController.php
+++ b/app/Http/Controllers/Api/FleetController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\District;
+use App\Models\Fleet;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 
@@ -33,6 +35,11 @@ class FleetController extends Controller
         $response = [
             'districts' => $districts,
             'fleets' => $fleets,
+            // Sentinel row ids so the frontend can special-case
+            // "Unaffiliated/None" (always-selectable fleet, blank-district
+            // auto-fill) without string matching
+            'none_district_id' => District::noneId(),
+            'none_fleet_id' => Fleet::noneId(),
         ];
 
         return response()->json($response);

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -94,7 +94,7 @@ class ExportController extends Controller
                             $flash->location ?? '',
                             $flash->sail_number ?? '',
                             data_get($member, 'district.name', ''),
-                            data_get($member, 'fleet.fleet_number', ''),
+                            data_get($member, 'fleet.fleet_number') ?: '',  // 0 = the None fleet
                             data_get($member, 'fleet.fleet_name', ''),
                             $flash->notes ?? '',
                             $flash->created_at ?? '',

--- a/app/Livewire/AdminAwardsDashboard.php
+++ b/app/Livewire/AdminAwardsDashboard.php
@@ -606,7 +606,7 @@ class AdminAwardsDashboard extends AdminComponent
 
                             fputcsv($handle, [
                                 $user->name,
-                                ($membership?->fleet->fleet_number ?? null) ?: '—',  // 0 = the None fleet
+                                $membership?->fleet?->fleet_number ?: '—',  // 0 = the None fleet
                                 $membership?->district->name ?? '—',
                                 $user->email,
                                 $user->email_verified_at ? 'Yes' : 'No',

--- a/app/Livewire/AdminAwardsDashboard.php
+++ b/app/Livewire/AdminAwardsDashboard.php
@@ -606,7 +606,7 @@ class AdminAwardsDashboard extends AdminComponent
 
                             fputcsv($handle, [
                                 $user->name,
-                                $membership?->fleet->fleet_number ?? '—',
+                                ($membership?->fleet->fleet_number ?? null) ?: '—',  // 0 = the None fleet
                                 $membership?->district->name ?? '—',
                                 $user->email,
                                 $user->email_verified_at ? 'Yes' : 'No',

--- a/app/Livewire/Leaderboard.php
+++ b/app/Livewire/Leaderboard.php
@@ -98,7 +98,8 @@ class Leaderboard extends Component
                 groupByColumns: ['fleets.id', 'fleets.fleet_number', 'fleets.fleet_name'],
                 userFlashesSubquery: $userFlashesSubquery,
                 mostRecentMembershipSubquery: $mostRecentMembershipSubquery,
-                year: $year
+                year: $year,
+                excludeId: Fleet::noneId()
             ),
             'district' => $this->buildGroupedQuery(
                 table: 'districts',
@@ -107,7 +108,8 @@ class Leaderboard extends Component
                 groupByColumns: ['districts.id', 'districts.name'],
                 userFlashesSubquery: $userFlashesSubquery,
                 mostRecentMembershipSubquery: $mostRecentMembershipSubquery,
-                year: $year
+                year: $year,
+                excludeId: District::noneId()
             ),
             default => $this->buildSailorQuery($userFlashesSubquery, $mostRecentMembershipSubquery, $year),
         };
@@ -152,7 +154,8 @@ class Leaderboard extends Component
         array $groupByColumns,
         $userFlashesSubquery,
         $mostRecentMembershipSubquery,
-        int $year
+        int $year,
+        int $excludeId = 0
     ): LengthAwarePaginator {
         $aggregatedColumns = [
             DB::raw('COUNT(DISTINCT recent_members.user_id) as member_count'),
@@ -166,6 +169,8 @@ class Leaderboard extends Component
 
         return DB::table($table)
             ->select(array_merge($selectColumns, $aggregatedColumns))
+            // The sentinel Unaffiliated/None row never ranks
+            ->where("{$table}.id", '!=', $excludeId)
             ->joinSub($mostRecentMembershipSubquery, 'recent_members', "{$table}.id", '=', $joinColumn)
             ->joinSub($userFlashesSubquery, 'user_flashes', 'recent_members.user_id', '=', 'user_flashes.user_id')
             ->groupBy($groupByColumns)

--- a/app/Livewire/ProfileForm.php
+++ b/app/Livewire/ProfileForm.php
@@ -43,10 +43,10 @@ class ProfileForm extends Component
     public string $country = '';
 
     // Lightning Class Info (from current membership)
-    // mixed, not ?int: pre-filled as an int from the membership row, then a
-    // numeric string once the JS re-syncs it (HTML select values). null only
-    // while the JS has auto-cleared the fleet after a district change.
-    // "Unaffiliated/None" is a real district/fleet row.
+    // mixed, not ?int: pre-filled as ints from the membership row, then
+    // numeric strings once the JS re-syncs them (HTML select values).
+    // fleet_id alone can also be null: the JS auto-clears it when the
+    // district changes. "Unaffiliated/None" is a real district/fleet row.
     public mixed $district_id = null;
 
     public mixed $fleet_id = null;

--- a/app/Livewire/ProfileForm.php
+++ b/app/Livewire/ProfileForm.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Livewire\Concerns\SuggestsEmailCorrections;
+use App\Models\District;
 use App\Models\Fleet;
 use App\Models\Member;
 use App\Models\User;
@@ -42,8 +43,10 @@ class ProfileForm extends Component
     public string $country = '';
 
     // Lightning Class Info (from current membership)
-    // mixed, not ?int: holds 'none' (the TomSelect Unaffiliated/None option)
-    // until save() normalizes it to null after validation.
+    // mixed, not ?int: pre-filled as an int from the membership row, then a
+    // numeric string once the JS re-syncs it (HTML select values). null only
+    // while the JS has auto-cleared the fleet after a district change.
+    // "Unaffiliated/None" is a real district/fleet row.
     public mixed $district_id = null;
 
     public mixed $fleet_id = null;
@@ -83,8 +86,36 @@ class ProfileForm extends Component
     public function rules()
     {
         $user = auth()->user();
+        $rules = UserProfileRules::rules((string) $user->id, false);
 
-        return UserProfileRules::rules((string) $user->id, false);
+        // Same explicit-selection closures as RegistrationForm: null/''/0 =
+        // untouched or auto-cleared by the JS. Run for both validateOnly()
+        // and validate(); 'nullable' is intentionally omitted — it
+        // short-circuits closures on null values.
+        $rules['district_id'] = [
+            function ($attr, $value, $fail) {
+                if (in_array($value, ['', null, 0, '0'], true)) {
+                    $fail('Please select a district or choose Unaffiliated/None.');
+                } elseif (! District::where('id', $value)->exists()) {
+                    $fail('The selected district is invalid.');
+                }
+            },
+        ];
+        $rules['fleet_id'] = [
+            function ($attr, $value, $fail) {
+                if (in_array($value, ['', null, 0, '0'], true)) {
+                    // Reached on save when the JS auto-cleared the fleet after
+                    // a district change and the user never re-picked.
+                    $fail('Please select a fleet or choose None.');
+                } elseif ((int) $value !== Fleet::noneId() && ! Fleet::where('id', $value)->where('district_id', $this->district_id)->exists()) {
+                    // The None fleet may accompany ANY district; a real fleet
+                    // must exist AND belong to the selected district.
+                    $fail('The selected fleet is invalid.');
+                }
+            },
+        ];
+
+        return $rules;
     }
 
     public function messages()
@@ -103,15 +134,11 @@ class ProfileForm extends Component
 
         // District/fleet are cleared programmatically (picking a district clears
         // the fleet), so don't flag them while empty — that would error an
-        // untouched field. 'none' is the explicit Unaffiliated/None pick, which
-        // only save() normalizes to null — the base exists:… rule here would
-        // reject the sentinel on the spot. They still validate on save. An
-        // explicit None pick must still CLEAR a stale "pick a fleet" error
-        // left by a failed save, hence the resetValidation.
+        // untouched field. They still validate on save. Any real pick —
+        // including Unaffiliated/None, which is a real row — falls through to
+        // validateOnly(), which also clears a stale error from a failed save.
         if (in_array($propertyName, ['district_id', 'fleet_id'], true)
-            && in_array($this->{$propertyName}, ['none', '', null, 0, '0'], true)) {
-            $this->resetValidation($propertyName);
-
+            && in_array($this->{$propertyName}, ['', null, 0, '0'], true)) {
             return;
         }
 
@@ -128,44 +155,10 @@ class ProfileForm extends Component
         // lowercased/trimmed form.
         $this->email = User::normalizeEmail($this->email);
 
-        // Capture raw values to distinguish "explicit None" ('none') from auto-clear (null)
-        // before normalization. JS sends 'none' for an explicit pick; null for auto-clear.
-        // Real ids arrive as STRINGS (HTML select values; the TomSelect init re-syncs them
-        // even untouched), so cast to int — the district-changed check below compares
-        // against the DB's int with !==, and "5" !== 5 would misread a no-op save as a
-        // district change and demand a fleet re-pick.
-        $fleetRaw = $this->fleet_id;
-        if (in_array($this->district_id, ['none', '', null, 0, '0'], true)) {
-            $this->district_id = null;
-        } else {
-            $this->district_id = (int) $this->district_id;
-        }
-        if (in_array($this->fleet_id, ['none', '', null, 0, '0'], true)) {
-            $this->fleet_id = null;
-        } else {
-            $this->fleet_id = (int) $this->fleet_id;
-        }
-
-        // Detect "district changed, fleet was auto-cleared, user didn't re-select".
-        // Auto-clear is identified by: district differs from DB AND fleet arrived as raw null
-        // (an explicit None pick would have arrived as 'none').
-        $originalDistrict = $user->currentMembership()?->district_id;
-        $rules = UserProfileRules::rules((string) $user->id, false);
-        $rules['fleet_id'] = [
-            function ($attr, $value, $fail) use ($originalDistrict, $fleetRaw) {
-                $districtChanged = $this->district_id !== $originalDistrict;
-                if ($districtChanged && $fleetRaw === null) {
-                    $fail('Please select a fleet or choose None.');
-                } elseif ($value !== null && ! Fleet::where('id', $value)->where('district_id', $this->district_id)->exists()) {
-                    // Every fleet belongs to a district, so the fleet must exist
-                    // AND belong to the selected district — rejecting a cross-district
-                    // fleet or a fleet with no district selected.
-                    $fail('The selected fleet is invalid.');
-                }
-            },
-        ];
-
-        $validated = $this->validate($rules);
+        // rules() requires an explicit district and fleet (Unaffiliated/None is
+        // a real row); an empty fleet here means the JS auto-cleared it on a
+        // district change and the user never re-picked.
+        $validated = $this->validate();
 
         // Check if email has changed
         $emailChanged = $validated['email'] !== $user->email;
@@ -196,8 +189,8 @@ class ProfileForm extends Component
                     'year' => now()->year,
                 ],
                 [
-                    'district_id' => $validated['district_id'] ?? null,
-                    'fleet_id' => $validated['fleet_id'] ?? null,
+                    'district_id' => (int) $validated['district_id'],
+                    'fleet_id' => (int) $validated['fleet_id'],
                 ]
             );
         });

--- a/app/Livewire/RegistrationForm.php
+++ b/app/Livewire/RegistrationForm.php
@@ -48,8 +48,8 @@ class RegistrationForm extends Component
     public string $country = 'United States';
 
     // Lightning Class Info
-    // mixed, not ?int: holds 'none' (the TomSelect Unaffiliated/None option)
-    // until register() normalizes it to null after validation.
+    // mixed, not ?int: null until touched, then a numeric id (as a string —
+    // HTML select values). "Unaffiliated/None" is a real district/fleet row.
     public mixed $district_id = null;
 
     public mixed $fleet_id = null;
@@ -59,15 +59,16 @@ class RegistrationForm extends Component
     public function rules()
     {
         $rules = UserProfileRules::rules(null, true);
-        // Override district/fleet to require explicit selection ('none' or a valid id).
-        // null/''/0 = untouched. These run for both validateOnly() (per-field on blur/change)
-        // and validate() (on submit). 'nullable' is intentionally omitted — it short-circuits
-        // closures on null values.
+        // Override district/fleet to require explicit selection. null/''/0 =
+        // untouched (or auto-cleared by the JS when the district changed).
+        // These run for both validateOnly() (per-field on blur/change) and
+        // validate() (on submit). 'nullable' is intentionally omitted — it
+        // short-circuits closures on null values.
         $rules['district_id'] = [
             function ($attr, $value, $fail) {
                 if (in_array($value, ['', null, 0, '0'], true)) {
                     $fail('Please select a district or choose Unaffiliated/None.');
-                } elseif ($value !== 'none' && ! District::where('id', $value)->exists()) {
+                } elseif (! District::where('id', $value)->exists()) {
                     $fail('The selected district is invalid.');
                 }
             },
@@ -76,11 +77,12 @@ class RegistrationForm extends Component
             function ($attr, $value, $fail) {
                 if (in_array($value, ['', null, 0, '0'], true)) {
                     $fail('Please select a fleet or choose None.');
-                } elseif ($value !== 'none' && ! Fleet::where('id', $value)->where('district_id', $this->district_id)->exists()) {
-                    // Every fleet belongs to a district, so the fleet must exist
-                    // AND belong to the selected district. This rejects both a
-                    // cross-district fleet and a fleet with no district selected
-                    // (the frontend filters by district and auto-sets it).
+                } elseif ((int) $value !== Fleet::noneId() && ! Fleet::where('id', $value)->where('district_id', $this->district_id)->exists()) {
+                    // The None fleet may accompany ANY district; a real fleet
+                    // must exist AND belong to the selected district. This
+                    // rejects both a cross-district fleet and a fleet with no
+                    // district selected (the frontend filters by district and
+                    // auto-sets it).
                     $fail('The selected fleet is invalid.');
                 }
             },
@@ -148,18 +150,10 @@ class RegistrationForm extends Component
         // that never triggered the updated() hook).
         $this->email = User::normalizeEmail($this->email);
 
-        // Validation uses rules() which includes district/fleet "explicit selection required" closures.
-        // 'none' is accepted as a valid explicit choice — normalized to null after validation passes.
+        // Validation uses rules() which includes district/fleet "explicit selection
+        // required" closures. Unaffiliated/None is a real district/fleet row, so
+        // its ids validate like any other selection.
         $validated = $this->validate();
-
-        if ($this->district_id === 'none') {
-            $this->district_id = null;
-            $validated['district_id'] = null;
-        }
-        if ($this->fleet_id === 'none') {
-            $this->fleet_id = null;
-            $validated['fleet_id'] = null;
-        }
 
         // Create user and membership in a transaction
         $user = DB::transaction(function () use ($validated) {
@@ -172,11 +166,12 @@ class RegistrationForm extends Component
             // Create the user
             $user = User::create($userData);
 
-            // Always create membership record for current year (even if unaffiliated)
+            // Always create membership record for current year (unaffiliated =
+            // the None district/fleet)
             Member::create(UserDataService::buildMemberData(
                 $user->id,
-                $validated['district_id'] ?? null,
-                $validated['fleet_id'] ?? null,
+                (int) $validated['district_id'],
+                (int) $validated['fleet_id'],
                 now()->year
             ));
 

--- a/app/Livewire/SailorLogs.php
+++ b/app/Livewire/SailorLogs.php
@@ -192,7 +192,7 @@ class SailorLogs extends AdminComponent
                         $flash->location ?? '—',
                         $flash->sail_number ?? '—',
                         $membership?->district->name ?? '—',
-                        $membership?->fleet->fleet_number ?? '—',
+                        $membership?->fleet?->fleet_number ?: '—',  // 0 = the None fleet
                         $user->yacht_club ?? '—',
                         $flash->notes ?? '',
                         $flash->created_at->format('Y-m-d H:i:s'),

--- a/app/Models/District.php
+++ b/app/Models/District.php
@@ -24,9 +24,10 @@ class District extends Model
 
     public static function noneId(): int
     {
-        // once(): the id is fixed after the migration runs, and rules()/API
-        // endpoints call this repeatedly per request. Laravel flushes the
-        // memo between tests, so RefreshDatabase stays safe.
+        // once(): rules()/API endpoints call this repeatedly per request.
+        // The sentinel row is immutable after the migration runs, so even a
+        // long-lived worker can't cache a stale id; Laravel flushes the memo
+        // between tests, so RefreshDatabase stays safe.
         return once(fn (): int => (int) static::query()->where('name', self::NONE_NAME)->value('id'));
     }
 

--- a/app/Models/District.php
+++ b/app/Models/District.php
@@ -24,7 +24,10 @@ class District extends Model
 
     public static function noneId(): int
     {
-        return (int) static::query()->where('name', self::NONE_NAME)->value('id');
+        // once(): the id is fixed after the migration runs, and rules()/API
+        // endpoints call this repeatedly per request. Laravel flushes the
+        // memo between tests, so RefreshDatabase stays safe.
+        return once(fn (): int => (int) static::query()->where('name', self::NONE_NAME)->value('id'));
     }
 
     /**

--- a/app/Models/District.php
+++ b/app/Models/District.php
@@ -16,6 +16,18 @@ class District extends Model
     ];
 
     /**
+     * The sentinel "Unaffiliated/None" district — a real row (created by the
+     * make_none_a_real_district_and_fleet migration) so member affiliations
+     * are never null. Excluded from the district leaderboard.
+     */
+    public const NONE_NAME = 'Unaffiliated/None';
+
+    public static function noneId(): int
+    {
+        return (int) static::query()->where('name', self::NONE_NAME)->value('id');
+    }
+
+    /**
      * Get the fleets for the district.
      */
     public function fleets(): HasMany

--- a/app/Models/Fleet.php
+++ b/app/Models/Fleet.php
@@ -27,7 +27,10 @@ class Fleet extends Model
 
     public static function noneId(): int
     {
-        return (int) static::query()->where('fleet_number', self::NONE_NUMBER)->value('id');
+        // once(): the id is fixed after the migration runs, and rules()/API
+        // endpoints call this repeatedly per request. Laravel flushes the
+        // memo between tests, so RefreshDatabase stays safe.
+        return once(fn (): int => (int) static::query()->where('fleet_number', self::NONE_NUMBER)->value('id'));
     }
 
     /**

--- a/app/Models/Fleet.php
+++ b/app/Models/Fleet.php
@@ -19,6 +19,18 @@ class Fleet extends Model
     ];
 
     /**
+     * Fleet number of the sentinel "None" fleet (real fleets are numbered
+     * from 1). A real row so member affiliations are never null; selectable
+     * alongside ANY district, and excluded from the fleet leaderboard.
+     */
+    public const NONE_NUMBER = 0;
+
+    public static function noneId(): int
+    {
+        return (int) static::query()->where('fleet_number', self::NONE_NUMBER)->value('id');
+    }
+
+    /**
      * Get the district that owns the fleet.
      */
     public function district(): BelongsTo

--- a/app/Models/Fleet.php
+++ b/app/Models/Fleet.php
@@ -27,9 +27,10 @@ class Fleet extends Model
 
     public static function noneId(): int
     {
-        // once(): the id is fixed after the migration runs, and rules()/API
-        // endpoints call this repeatedly per request. Laravel flushes the
-        // memo between tests, so RefreshDatabase stays safe.
+        // once(): rules()/API endpoints call this repeatedly per request.
+        // The sentinel row is immutable after the migration runs, so even a
+        // long-lived worker can't cache a stale id; Laravel flushes the memo
+        // between tests, so RefreshDatabase stays safe.
         return once(fn (): int => (int) static::query()->where('fleet_number', self::NONE_NUMBER)->value('id'));
     }
 

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -27,6 +27,8 @@ class Member extends Model
 
     /**
      * Get the district for this membership.
+     *
+     * @return BelongsTo<District, $this>
      */
     public function district(): BelongsTo
     {
@@ -35,6 +37,8 @@ class Member extends Model
 
     /**
      * Get the fleet for this membership.
+     *
+     * @return BelongsTo<Fleet, $this>
      */
     public function fleet(): BelongsTo
     {

--- a/app/Rules/UserProfileRules.php
+++ b/app/Rules/UserProfileRules.php
@@ -31,8 +31,10 @@ class UserProfileRules
             'state' => ['required', 'string', 'max:255'],
             'zip_code' => ['required', 'string', 'max:20'],
             'country' => ['required', 'string', 'max:255'],
-            'district_id' => ['nullable', 'exists:districts,id'],
-            'fleet_id' => ['nullable', 'exists:fleets,id'],
+            // district_id/fleet_id intentionally absent: both consumers
+            // (RegistrationForm, ProfileForm) define explicit-selection
+            // closures — a nullable base rule here would be dead code that
+            // misleadingly suggests null is acceptable.
             'yacht_club' => ['nullable', 'string', 'max:255'],
         ];
 

--- a/app/Services/UserDataService.php
+++ b/app/Services/UserDataService.php
@@ -8,24 +8,6 @@ use Illuminate\Support\Str;
 class UserDataService
 {
     /**
-     * Normalize "none" values to null for district/fleet IDs.
-     *
-     * @param  array<string, mixed>  $data
-     * @return array<string, mixed>
-     */
-    public static function normalizeAffiliationIds(array $data): array
-    {
-        if (isset($data['district_id']) && in_array($data['district_id'], ['none', '', null, 0], true)) {
-            $data['district_id'] = null;
-        }
-        if (isset($data['fleet_id']) && in_array($data['fleet_id'], ['none', '', null, 0], true)) {
-            $data['fleet_id'] = null;
-        }
-
-        return $data;
-    }
-
-    /**
      * Build user data array from validated input (for create/update).
      *
      * @param  array<string, mixed>  $validated
@@ -78,7 +60,7 @@ class UserDataService
      *
      * @return array<string, mixed>
      */
-    public static function buildMemberData(int $userId, ?int $districtId, ?int $fleetId, int $year): array
+    public static function buildMemberData(int $userId, int $districtId, int $fleetId, int $year): array
     {
         return [
             'user_id' => $userId,

--- a/database/migrations/2026_07_18_210000_make_none_a_real_district_and_fleet.php
+++ b/database/migrations/2026_07_18_210000_make_none_a_real_district_and_fleet.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Make "Unaffiliated/None" a real district and fleet instead of NULL.
+     *
+     * The nullable columns forced a three-way sentinel dance ('none' string
+     * from the UI vs null vs untouched) through both profile/registration
+     * forms and produced a string of validation bugs. With real rows:
+     * - district_id/fleet_id are always valid foreign keys (NOT NULL),
+     * - "None" validates like any other selection (plain exists checks),
+     * - leaderboards exclude the None rows explicitly instead of relying on
+     *   inner joins dropping nulls.
+     *
+     * The None fleet gets fleet_number 0 (real fleets are numbered from 1)
+     * and belongs to the None district; validation special-cases it as
+     * selectable alongside ANY district. No production members are
+     * unaffiliated at migration time, so the backfill is a no-op there —
+     * it exists for dev/test databases.
+     */
+    private const NONE_DISTRICT_NAME = 'Unaffiliated/None';
+
+    private const NONE_FLEET_NUMBER = 0;
+
+    public function up(): void
+    {
+        $noneDistrictId = DB::table('districts')->where('name', self::NONE_DISTRICT_NAME)->value('id')
+            ?? DB::table('districts')->insertGetId([
+                'name' => self::NONE_DISTRICT_NAME,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        $noneFleetId = DB::table('fleets')->where('fleet_number', self::NONE_FLEET_NUMBER)->value('id')
+            ?? DB::table('fleets')->insertGetId([
+                'district_id' => $noneDistrictId,
+                'fleet_number' => self::NONE_FLEET_NUMBER,
+                'fleet_name' => 'None',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        DB::table('members')->whereNull('district_id')->update([
+            'district_id' => $noneDistrictId,
+            'updated_at' => now(),
+        ]);
+        DB::table('members')->whereNull('fleet_id')->update([
+            'fleet_id' => $noneFleetId,
+            'updated_at' => now(),
+        ]);
+
+        Schema::table('members', function (Blueprint $table) {
+            $table->foreignId('district_id')->nullable(false)->change();
+            $table->foreignId('fleet_id')->nullable(false)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->foreignId('district_id')->nullable()->change();
+            $table->foreignId('fleet_id')->nullable()->change();
+        });
+
+        $noneDistrictId = DB::table('districts')->where('name', self::NONE_DISTRICT_NAME)->value('id');
+        $noneFleetId = DB::table('fleets')->where('fleet_number', self::NONE_FLEET_NUMBER)->value('id');
+
+        if ($noneFleetId !== null) {
+            DB::table('members')->where('fleet_id', $noneFleetId)->update(['fleet_id' => null, 'updated_at' => now()]);
+            DB::table('fleets')->where('id', $noneFleetId)->delete();
+        }
+        if ($noneDistrictId !== null) {
+            DB::table('members')->where('district_id', $noneDistrictId)->update(['district_id' => null, 'updated_at' => now()]);
+            DB::table('districts')->where('id', $noneDistrictId)->delete();
+        }
+    }
+};

--- a/docs/membership-year-end-logic.md
+++ b/docs/membership-year-end-logic.md
@@ -32,17 +32,20 @@ The `members` table tracks per-year affiliations:
 ```
 members
   - user_id (foreign key to users)
-  - district_id (foreign key to districts, nullable)
-  - fleet_id (foreign key to fleets, nullable)
+  - district_id (foreign key to districts, NOT NULL)
+  - fleet_id (foreign key to fleets, NOT NULL)
   - year (integer)
   - unique constraint on (user_id, year)
 ```
 
 **Key Constraints:**
 - One membership record per user per year
-- Both `district_id` and `fleet_id` are nullable (for unaffiliated users)
+- `district_id` and `fleet_id` are NOT NULL — "Unaffiliated/None" is a real
+  district row and a real fleet row (fleet_number 0, always selectable
+  alongside any district; both excluded from the grouped leaderboards).
+  See the `make_none_a_real_district_and_fleet` migration.
 - Cascade delete when the user is deleted
-- Set null when a district/fleet is deleted
+- Deleting a district/fleet that still has member records is blocked
 
 ### 3. When Membership Records Are Created or Updated
 
@@ -50,7 +53,7 @@ members
 - A membership record is created for the **current year** only
   (`RegistrationForm`, via `UserDataService::buildMemberData(...)`)
 - Uses the `district_id` / `fleet_id` selected during registration
-- If the user selects "Unaffiliated/None", both fields are null
+- If the user selects "Unaffiliated/None", the sentinel None district/fleet ids are stored
 
 **On Profile Update:**
 - Updating district/fleet in the profile writes to the **current year's** membership row
@@ -74,7 +77,7 @@ carry-forward subquery (`Leaderboard.php`), then aggregate:
 
 ### 5. Unaffiliated Users
 
-Users with `district_id` and/or `fleet_id` set to null for the resolved year:
+Users whose resolved membership points at the None district/fleet rows:
 - Have their flashes count toward their personal totals
 - Do **not** contribute to district or fleet leaderboard totals
 - Still appear on the sailor leaderboard
@@ -138,8 +141,9 @@ public function currentMembership(): ?Member
 - Membership records are cascade-deleted; historical leaderboard data no longer includes them.
 
 **District/Fleet deleted:**
-- Affected membership rows have `district_id`/`fleet_id` set to null; those users become
-  unaffiliated for the affected years. Historical flash data is preserved but unattributed.
+- Blocked while member records still reference the row (`district_id`/`fleet_id`
+  are NOT NULL); reassign the members first. Reference data is effectively
+  append-only in practice.
 
 ### 8. Implementation Notes & Possible Future Work
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -305,6 +305,13 @@
     outline-color: var(--color-error);
 }
 
+/* A select still showing its empty-value placeholder option ("Select activity
+   type…") has no value yet — dim it to match input ::placeholder (DaisyUI:
+   currentcolor at 50%) so it can't be mistaken for a real selection. */
+.select:has(option[value='']:checked) {
+    color: color-mix(in oklab, currentcolor 50%, transparent);
+}
+
 /* Native <select> dropdown options (stylable in Chromium; Firefox/Safari show
    the OS picker regardless): selection is marked by the picker's own checkmark
    only — no fill (DaisyUI paints the checked row base-content, which also lit

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -312,6 +312,7 @@
     color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
+
 /* Native <select> dropdown options (stylable in Chromium; Firefox/Safari show
    the OS picker regardless): selection is marked by the picker's own checkmark
    only — no fill (DaisyUI paints the checked row base-content, which also lit
@@ -327,6 +328,13 @@
     background-color: color-mix(in oklab, var(--color-base-content) 10%, transparent);
     color: var(--color-base-content);
     box-shadow: none;
+}
+
+/* Placeholder dimming targets the closed control's displayed text; option rows
+   in the open picker inherit the select's color in Chromium, so restore full
+   contrast for the actual choices. */
+.select:has(option[value='']:checked) option {
+    color: var(--color-base-content);
 }
 
 .ts-wrapper.disabled .ts-control,

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -272,24 +272,28 @@
 }
 
 .ts-wrapper.focus .ts-control {
-    border-color: var(--color-primary);
-    box-shadow: 0 0 0 3px oklch(from var(--color-primary) l c h / 20%);
+    /* Secondary to match the native focus rings (see the .input:focus block) */
+    border-color: var(--color-secondary);
+    box-shadow: 0 0 0 3px oklch(from var(--color-secondary) l c h / 20%);
     outline: none;
     background: var(--color-base-100) !important;
 }
 
 /* Brand-blue focus ring on native DaisyUI form controls (DaisyUI 5's default
-   focus outline is base-content, which reads as black). --input-color also
-   drives DaisyUI's focus box-shadow underline. */
+   focus outline is base-content, which reads as black). Secondary, not
+   primary: thin strokes lose perceived hue, so the dark primary navy also
+   read near-black at 2px — and secondary is already the interaction color
+   (links, tooltips). --input-color also drives DaisyUI's focus box-shadow
+   underline. */
 .input:focus,
 .input:focus-within,
 .select:focus,
 .select:focus-within,
 .textarea:focus,
 .textarea:focus-within {
-    --input-color: var(--color-primary);
+    --input-color: var(--color-secondary);
 
-    outline-color: var(--color-primary);
+    outline-color: var(--color-secondary);
 }
 
 /* Error-state fields keep an error-colored focus, mirroring

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -316,7 +316,6 @@
     color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
-
 /* Native <select> dropdown options (stylable in Chromium; Firefox/Safari show
    the OS picker regardless): selection is marked by the picker's own checkmark
    only — no fill (DaisyUI paints the checked row base-content, which also lit

--- a/resources/js/utils/district-fleet-select.js
+++ b/resources/js/utils/district-fleet-select.js
@@ -1,7 +1,12 @@
 import TomSelect from 'tom-select';
 
 /**
- * Initialize district and fleet TomSelect dropdowns with smart filtering
+ * Initialize district and fleet TomSelect dropdowns with smart filtering.
+ *
+ * "Unaffiliated/None" is a real district and fleet row (fleet_number 0); the
+ * API reports their ids as none_district_id / none_fleet_id. The None fleet
+ * is selectable alongside ANY district.
+ *
  * @param {Object} config - Configuration object
  * @param {string} config.districtSelectId - ID of the district select element
  * @param {string} config.fleetSelectId - ID of the fleet select element
@@ -28,6 +33,8 @@ export async function initializeDistrictFleetSelects(config) {
     // these are never read while still undefined.
     let districts;
     let fleets;
+    let noneDistrictId;
+    let noneFleetId;
 
     // Fetch data from API (combined endpoint for better performance and to avoid SQLite locking)
     try {
@@ -40,6 +47,8 @@ export async function initializeDistrictFleetSelects(config) {
         const data = await response.json();
         districts = data.districts;
         fleets = data.fleets;
+        noneDistrictId = String(data.none_district_id);
+        noneFleetId = String(data.none_fleet_id);
     } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Error fetching districts and fleets:', error);
@@ -64,12 +73,11 @@ export async function initializeDistrictFleetSelects(config) {
         return null;
     }
 
-    // Initialize District Select
+    const isNoneFleet = (value) => String(value) === noneFleetId;
+
+    // Initialize District Select (the None district is a real row in the list)
     const districtTomSelect = new TomSelect(`#${districtSelectId}`, {
-        options: [
-            { value: 'none', text: 'Unaffiliated/None', id: null },
-            ...districts.map(d => ({ value: d.id, text: d.name, id: d.id, name: d.name }))
-        ],
+        options: districts.map(d => ({ value: d.id, text: d.name, id: d.id, name: d.name })),
         placeholder: 'Select district...',
         allowEmptyOption: true,
         maxOptions: null,
@@ -81,29 +89,30 @@ export async function initializeDistrictFleetSelects(config) {
         onChange: function(value) {
             if (value) this.blur();
 
-            // Callback for Livewire sync — send 'none' literally for explicit unaffiliated
+            // Callback for Livewire sync
             if (onDistrictChange) {
                 onDistrictChange(value);
             }
 
             // Clear fleet selection when district changes — user must re-select.
-            // Server detects this via comparison to DB state (profile) or null check (registration).
+            // Server detects this via the empty fleet value on submit.
             fleetTomSelect.clear();
             if (onFleetChange) {
                 onFleetChange(null);
             }
 
-            if (value === 'none') {
-                updateFleetOptions(fleets, false);
+            if (String(value) === noneDistrictId) {
+                // Unaffiliated district: any fleet is still selectable
+                // (picking a real fleet auto-sets its district below)
+                updateFleetOptions(fleets);
             } else if (value) {
-                const filteredFleets = fleets.filter(f => f.district_id == value);
-                updateFleetOptions(filteredFleets, false);
+                updateFleetOptions(fleets.filter(f => f.district_id == value || isNoneFleet(f.id)));
             } else {
                 // District was cleared - sync null to Livewire and show all fleets
                 if (onDistrictChange) {
                     onDistrictChange(null);
                 }
-                updateFleetOptions(fleets, false);
+                updateFleetOptions(fleets);
             }
         },
         onType: function(str) {
@@ -124,12 +133,12 @@ export async function initializeDistrictFleetSelects(config) {
         },
         render: {
             option: function(data, escape) {
-                if (data.value === 'none') return '<div>None</div>';
+                if (isNoneFleet(data.value)) return '<div>None</div>';
                 if (!data.fleet_number || !data.fleet_name) return '<div></div>';
                 return '<div>Fleet ' + escape(data.fleet_number) + ' - ' + escape(data.fleet_name) + '</div>';
             },
             item: function(data, escape) {
-                if (data.value === 'none') return '<div>None</div>';
+                if (isNoneFleet(data.value)) return '<div>None</div>';
                 if (!data.fleet_number || !data.fleet_name) return '<div></div>';
                 return '<div>Fleet ' + escape(data.fleet_number) + ' - ' + escape(data.fleet_name) + '</div>';
             }
@@ -138,19 +147,20 @@ export async function initializeDistrictFleetSelects(config) {
             if (value) {
                 this.blur();
 
-                // Callback for Livewire sync — send 'none' literally so server can distinguish from untouched/auto-cleared
+                // Callback for Livewire sync
                 if (onFleetChange) {
                     onFleetChange(value);
                 }
 
-                if (value === 'none') {
-                    // Special case: When fleet is set to 'none' and district is blank, set district to 'none'
+                if (isNoneFleet(value)) {
+                    // Special case: fleet set to None with a blank district —
+                    // fill the district as Unaffiliated/None too
                     const currentDistrict = districtTomSelect.getValue();
                     if (!currentDistrict || currentDistrict === '') {
-                        districtTomSelect.setValue('none', true);
+                        districtTomSelect.setValue(noneDistrictId, true);
                         // Explicitly sync to Livewire since silent=true skips onChange
                         if (onDistrictChange) {
-                            onDistrictChange(null);
+                            onDistrictChange(noneDistrictId);
                         }
                     }
                 } else {
@@ -177,35 +187,26 @@ export async function initializeDistrictFleetSelects(config) {
         }
     });
 
-    function updateFleetOptions(fleetList, showNoneOnly = false) {
+    function updateFleetOptions(fleetList) {
         fleetTomSelect.clearOptions();
 
-        if (!showNoneOnly) {
-            fleetList.forEach(fleet => {
-                fleetTomSelect.addOption({
-                    value: fleet.id,
-                    text: `Fleet ${fleet.fleet_number} - ${fleet.fleet_name}`,
-                    fleet_number: fleet.fleet_number,
-                    fleet_name: fleet.fleet_name,
-                    fleet_id: fleet.id,
-                    district_id: fleet.district_id,
-                    district_name: fleet.district_name
-                });
+        fleetList.forEach(fleet => {
+            fleetTomSelect.addOption({
+                value: fleet.id,
+                text: isNoneFleet(fleet.id) ? 'None' : `Fleet ${fleet.fleet_number} - ${fleet.fleet_name}`,
+                fleet_number: fleet.fleet_number,
+                fleet_name: fleet.fleet_name,
+                fleet_id: fleet.id,
+                district_id: fleet.district_id,
+                district_name: fleet.district_name
             });
-        }
-
-        fleetTomSelect.addOption({
-            value: 'none',
-            text: 'None',
-            fleet_number: 'None',
-            fleet_name: 'None'
         });
 
         fleetTomSelect.refreshOptions(false);
     }
 
-    // Initialize fleet options
-    updateFleetOptions(fleets, false);
+    // Initialize fleet options (the None fleet sorts first: fleet_number 0)
+    updateFleetOptions(fleets);
 
     // Set initial values from data attributes
     const initialDistrictId = districtSelect.dataset.value || districtSelect.dataset.oldValue;
@@ -216,8 +217,10 @@ export async function initializeDistrictFleetSelects(config) {
     if (initialDistrictId && initialDistrictId !== '' && initialDistrictId !== 'null') {
         districtTomSelect.setValue(initialDistrictId);
     } else if (isProfilePage) {
-        // On profile page, set to 'none' if district is null/empty (user has explicitly no district)
-        districtTomSelect.setValue('none', true);
+        // Safety net: profile memberships always carry real ids, but if one is
+        // ever missing, fall back to Unaffiliated/None — non-silent so the
+        // Livewire property stays in sync with what the UI shows
+        districtTomSelect.setValue(noneDistrictId);
     }
     // On signup, leave empty to show placeholder
 
@@ -225,8 +228,8 @@ export async function initializeDistrictFleetSelects(config) {
     if (initialFleetId && initialFleetId !== '' && initialFleetId !== 'null') {
         fleetTomSelect.setValue(initialFleetId);
     } else if (isProfilePage) {
-        // On profile page, set to 'none' if fleet is null/empty (user has explicitly no fleet)
-        fleetTomSelect.setValue('none', true);
+        // Same safety net as the district above
+        fleetTomSelect.setValue(noneFleetId);
     }
     // On signup, leave empty to show placeholder
 

--- a/resources/views/components/user-profile-fields.blade.php
+++ b/resources/views/components/user-profile-fields.blade.php
@@ -79,7 +79,9 @@
     <!-- Gender -->
     <div class="mb-6 floating-label-visible">
         <select wire:model.live.blur="gender" class="select select-bordered w-full @error('gender') select-error @enderror" required>
-            <option value="" disabled>Select gender</option>
+            {{-- hidden: placeholder text shows in the closed control but never
+                 as a (checkmarked) row in the open picker --}}
+            <option value="" disabled hidden>Select gender</option>
             <option value="male">Male</option>
             <option value="female">Female</option>
             <option value="non_binary">Non-binary</option>

--- a/resources/views/livewire/admin-awards-dashboard.blade.php
+++ b/resources/views/livewire/admin-awards-dashboard.blade.php
@@ -168,7 +168,7 @@
                                     </div>
                                 @endif
                             </td>
-                            <td class="text-center">{{ $membership?->fleet?->fleet_number ?? '—' }}</td>
+                            <td class="text-center">{{ $membership?->fleet?->fleet_number ?: '—' }}</td>
                             <td class="text-center">{{ $membership?->district?->name ?? '—' }}</td>
                             <td class="text-center">
                                 <span class="badge badge-primary">

--- a/resources/views/livewire/leaderboard.blade.php
+++ b/resources/views/livewire/leaderboard.blade.php
@@ -57,13 +57,13 @@
                                     @php
                                         $district = $user->district_id ? \App\Models\District::find($user->district_id) : null;
                                     @endphp
-                                    {{ $district?->name ?? '—' }}
+                                    {{ $district?->name === \App\Models\District::NONE_NAME ? '—' : ($district?->name ?? '—') }}
                                 </td>
                                 <td class="text-center">
                                     @php
                                         $fleet = $user->fleet_id ? \App\Models\Fleet::find($user->fleet_id) : null;
                                     @endphp
-                                    {{ $fleet?->fleet_number ?? '—' }}
+                                    {{ $fleet?->fleet_number ?: '—' }}
                                 </td>
                                 <td>{{ $user->yacht_club ?? '—' }}</td>
                                 <td class="text-center">

--- a/resources/views/livewire/leaderboard.blade.php
+++ b/resources/views/livewire/leaderboard.blade.php
@@ -57,7 +57,7 @@
                                     @php
                                         $district = $user->district_id ? \App\Models\District::find($user->district_id) : null;
                                     @endphp
-                                    {{ $district?->name === \App\Models\District::NONE_NAME ? '—' : ($district?->name ?? '—') }}
+                                    {{ $district?->id === \App\Models\District::noneId() ? '—' : ($district?->name ?? '—') }}
                                 </td>
                                 <td class="text-center">
                                     @php

--- a/resources/views/livewire/sailor-logs.blade.php
+++ b/resources/views/livewire/sailor-logs.blade.php
@@ -53,8 +53,8 @@
                                     data-fleet-number="{{ $fleet->fleet_number }}"
                                     data-district-id="{{ $fleet->district_id ?? '' }}"
                                     data-district-name="{{ $fleet->district_name ?? '' }}">
-                                Fleet {{ $fleet->fleet_number }}
-                                @if(!$selectedDistrict && isset($fleet->district_name))
+                                {{ $fleet->fleet_number ? 'Fleet '.$fleet->fleet_number : 'None' }}
+                                @if(!$selectedDistrict && isset($fleet->district_name) && $fleet->fleet_number)
                                     ({{ $fleet->district_name }})
                                 @endif
                             </option>
@@ -166,7 +166,7 @@
                             <td class="text-sm">{{ $flash->location ?? '—' }}</td>
                             <td class="text-sm">{{ $flash->sail_number ?? '—' }}</td>
                             <td class="text-sm">{{ $membership?->district->name ?? '—' }}</td>
-                            <td class="text-sm">{{ $membership?->fleet->fleet_number ?? '—' }}</td>
+                            <td class="text-sm">{{ $membership?->fleet->fleet_number ?: '—' }}</td>
                             <td class="text-sm max-w-xs truncate" title="{{ $flash->notes }}">
                                 {{ $flash->notes ?? '' }}
                             </td>

--- a/tests/Browser/Auth/RegistrationTest.php
+++ b/tests/Browser/Auth/RegistrationTest.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Str;
 */
 
 it('registers a new user with district + fleet and lands on /logbook', function () {
-    $district = District::first();
+    $district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
     $fleet = Fleet::where('district_id', $district->id)->first();
 
     $unique = Str::random(8);
@@ -45,7 +45,7 @@ it('registers a new user with district + fleet and lands on /logbook', function 
 });
 
 it('registers a new user with district and fleet set to None', function () {
-    $district = District::first();
+    $district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
 
     $unique = Str::random(8);
     $page = visit('/register');
@@ -62,7 +62,7 @@ it('registers a new user with district and fleet set to None', function () {
     // Set district, then explicitly pick None for fleet
     $page->script("document.getElementById('district-select').tomselect.setValue('{$district->id}')");
     settleLivewire($page);
-    $page->script("document.getElementById('fleet-select').tomselect.setValue('none')");
+    $page->script("document.getElementById('fleet-select').tomselect.setValue('".Fleet::noneId()."')");
     settleLivewire($page);
     $page->pressAndWaitFor('Register', 8)
         ->assertPathIs('/logbook');
@@ -81,9 +81,9 @@ it('registers a fully unaffiliated user', function () {
     ]);
 
     // Explicitly select None for both district and fleet (unaffiliated)
-    $page->script("document.getElementById('district-select').tomselect.setValue('none')");
+    $page->script("document.getElementById('district-select').tomselect.setValue('".District::noneId()."')");
     settleLivewire($page);
-    $page->script("document.getElementById('fleet-select').tomselect.setValue('none')");
+    $page->script("document.getElementById('fleet-select').tomselect.setValue('".Fleet::noneId()."')");
     settleLivewire($page);
     $page->pressAndWaitFor('Register', 8)
         ->assertPathIs('/logbook');
@@ -140,7 +140,7 @@ it('requires district and fleet selection on registration', function () {
 });
 
 it('requires fleet when district is set on registration', function () {
-    $district = District::first();
+    $district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
     $unique = Str::random(8);
     $page = visit('/register');
 
@@ -181,7 +181,7 @@ it('clears district error when district is selected after error', function () {
     $page->assertSee('Please select a district');
 
     // Select a district
-    $district = District::first();
+    $district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
     $page->script("document.getElementById('district-select').tomselect.setValue('{$district->id}')");
     settleLivewire($page);
     $page->assertDontSee('Please select a district');
@@ -197,7 +197,7 @@ it('keeps fleet error visible after picking district (fleet auto-clears, must st
     $page->assertSee('Please select a fleet');
 
     // Pick a district — JS auto-clears fleet, but error must stay
-    $district = District::first();
+    $district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
     $page->script("document.getElementById('district-select').tomselect.setValue('{$district->id}')");
     settleLivewire($page);
     $page->assertDontSee('Please select a district');
@@ -207,7 +207,7 @@ it('keeps fleet error visible after picking district (fleet auto-clears, must st
 it('clears fleet error when user picks a fleet after district', function () {
     $page = visit('/register');
     trackLivewireRequests($page);
-    $district = District::first();
+    $district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
     $fleet = Fleet::where('district_id', $district->id)->first();
 
     // Trigger both errors
@@ -235,9 +235,9 @@ it('shows verification banner immediately after registration', function () {
     ]);
 
     // Explicitly select None for both
-    $page->script("document.getElementById('district-select').tomselect.setValue('none')");
+    $page->script("document.getElementById('district-select').tomselect.setValue('".District::noneId()."')");
     settleLivewire($page);
-    $page->script("document.getElementById('fleet-select').tomselect.setValue('none')");
+    $page->script("document.getElementById('fleet-select').tomselect.setValue('".Fleet::noneId()."')");
     settleLivewire($page);
     $page->pressAndWaitFor('Register', 8)
         ->assertPathIs('/logbook')

--- a/tests/Browser/Profile/DistrictFleetTest.php
+++ b/tests/Browser/Profile/DistrictFleetTest.php
@@ -9,8 +9,8 @@ use Carbon\Carbon;
 beforeEach(function () {
     $this->travelTo(Carbon::parse('2027-01-15 12:00:00'));
 
-    $this->district = District::first();
-    $this->fleet = Fleet::where('district_id', $this->district->id)->first();
+    $this->district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
+    $this->fleet = Fleet::where('district_id', $this->district->id)->firstOrFail();
 
     $this->user = User::factory()->create([
         'first_name' => 'Fleet',
@@ -51,18 +51,18 @@ it('lets user set fleet to None', function () {
     // Verify fleet is initially set
     $page->assertScript("document.querySelector('#fleet-select').tomselect.getValue() !== ''", true);
 
-    // Clear fleet and save — set + call on same reference batches into one request
+    // Pick the None fleet and save — None is a real row, not a cleared value
+    $noneFleetId = Fleet::noneId();
+    $page->script("document.querySelector('#fleet-select').tomselect.setValue('{$noneFleetId}')");
+    $page->wait(1);
     $page->script("
-        document.querySelector('#fleet-select').tomselect.clear();
         const formEl = document.querySelector('#fleet-select').closest('[wire\\\\:id]');
-        const comp = Livewire.find(formEl.getAttribute('wire:id'));
-        comp.set('fleet_id', null);
-        comp.call('save');
+        Livewire.find(formEl.getAttribute('wire:id')).call('save');
     ");
     $page->assertSee('updated');
 
     $member = Member::where('user_id', $this->user->id)->where('year', 2027)->first();
-    expect($member->fleet_id)->toBeNull();
+    expect($member->fleet_id)->toBe(Fleet::noneId());
 });
 
 it('persists unaffiliated choice on save and reload', function () {
@@ -76,10 +76,12 @@ it('persists unaffiliated choice on save and reload', function () {
     $this->actingAs($this->user);
     $page = visit('/profile');
 
-    // User explicitly picks "Unaffiliated/None" for district (which auto-sets fleet to None too)
-    $page->script("document.querySelector('#district-select').tomselect.setValue('none')");
+    // User explicitly picks "Unaffiliated/None" for district and fleet
+    $noneDistrictId = District::noneId();
+    $noneFleetId = Fleet::noneId();
+    $page->script("document.querySelector('#district-select').tomselect.setValue('{$noneDistrictId}')");
     $page->wait(1);
-    $page->script("document.querySelector('#fleet-select').tomselect.setValue('none')");
+    $page->script("document.querySelector('#fleet-select').tomselect.setValue('{$noneFleetId}')");
     $page->wait(1);
 
     $page->script("
@@ -88,11 +90,10 @@ it('persists unaffiliated choice on save and reload', function () {
     ");
     $page->assertSee('updated');
 
-    // Reload and verify
+    // Reload and verify the saved None ids round-trip
     $page2 = visit('/profile');
-    // App auto-sets "none" for unaffiliated (via district-fleet-select.js)
-    $page2->assertScript("document.querySelector('#district-select').tomselect.getValue()", 'none');
-    $page2->assertScript("document.querySelector('#fleet-select').tomselect.getValue()", 'none');
+    $page2->assertScript("document.querySelector('#district-select').tomselect.getValue()", (string) District::noneId());
+    $page2->assertScript("document.querySelector('#fleet-select').tomselect.getValue()", (string) Fleet::noneId());
 });
 
 it('blocks save when district change clears fleet and user does not re-select', function () {
@@ -107,7 +108,8 @@ it('blocks save when district change clears fleet and user does not re-select', 
     $page = visit('/profile');
 
     // Change to a different district — JS auto-clears fleet to null; server detects this via DB comparison
-    $otherDistrict = District::where('id', '!=', $this->district->id)->first();
+    $otherDistrict = District::where('id', '!=', $this->district->id)
+        ->where('name', '!=', District::NONE_NAME)->firstOrFail();
     $page->script("document.getElementById('district-select').tomselect.setValue('{$otherDistrict->id}')");
     $page->wait(1);
 
@@ -134,7 +136,8 @@ it('clears fleet error when fleet is selected after district change', function (
     $page = visit('/profile');
 
     // Change district to trigger fleet auto-clear
-    $otherDistrict = District::where('id', '!=', $this->district->id)->first();
+    $otherDistrict = District::where('id', '!=', $this->district->id)
+        ->where('name', '!=', District::NONE_NAME)->firstOrFail();
     $page->script("document.getElementById('district-select').tomselect.setValue('{$otherDistrict->id}')");
     $page->wait(1);
 
@@ -145,7 +148,8 @@ it('clears fleet error when fleet is selected after district change', function (
     ");
     $page->assertSee('Please select a fleet');
 
-    // Now pick None
-    $page->script("document.getElementById('fleet-select').tomselect.setValue('none')");
+    // Now pick None (a real fleet row — live validation passes and clears the error)
+    $noneFleetId = Fleet::noneId();
+    $page->script("document.getElementById('fleet-select').tomselect.setValue('{$noneFleetId}')");
     $page->assertDontSee('Please select a fleet');
 });

--- a/tests/Feature/Api/FleetControllerTest.php
+++ b/tests/Feature/Api/FleetControllerTest.php
@@ -39,7 +39,12 @@ class FleetControllerTest extends TestCase
                 'fleets' => [
                     '*' => ['id', 'fleet_number', 'fleet_name', 'district_id', 'district_name'],
                 ],
+                'none_district_id',
+                'none_fleet_id',
             ]);
+
+        $this->assertSame(District::noneId(), $response->json('none_district_id'));
+        $this->assertSame(Fleet::noneId(), $response->json('none_fleet_id'));
     }
 
     public function test_fleets_include_district_name(): void

--- a/tests/Feature/EmailNormalizationTest.php
+++ b/tests/Feature/EmailNormalizationTest.php
@@ -4,6 +4,9 @@ namespace Tests\Feature;
 
 use App\Livewire\ProfileForm;
 use App\Livewire\RegistrationForm;
+use App\Models\District;
+use App\Models\Fleet;
+use App\Models\Member;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Features\SupportTesting\Testable;
@@ -35,8 +38,8 @@ class EmailNormalizationTest extends TestCase
             'state' => 'CA',
             'zip_code' => '12345',
             'country' => 'USA',
-            'district_id' => 'none',
-            'fleet_id' => 'none',
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
             'yacht_club' => '',
         ], $overrides);
 
@@ -113,6 +116,13 @@ class EmailNormalizationTest extends TestCase
     public function test_profile_email_change_stores_pending_email_lowercased(): void
     {
         $user = User::factory()->create(['email' => 'current@example.com']);
+        // Profile saves require an affiliation (every registered user has one)
+        Member::create([
+            'user_id' => $user->id,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
+            'year' => now()->year,
+        ]);
         $this->actingAs($user);
 
         Livewire::test(ProfileForm::class)

--- a/tests/Feature/EmailVerificationRateLimitTest.php
+++ b/tests/Feature/EmailVerificationRateLimitTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Livewire\RegistrationForm;
+use App\Models\District;
+use App\Models\Fleet;
 use App\Models\User;
 use App\Notifications\VerifyEmailChange;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -261,8 +263,8 @@ class EmailVerificationRateLimitTest extends TestCase
                 ->set('state', $data['state'])
                 ->set('zip_code', $data['zip_code'])
                 ->set('country', $data['country'])
-                ->set('district_id', 'none')
-                ->set('fleet_id', 'none')
+                ->set('district_id', District::noneId())
+                ->set('fleet_id', Fleet::noneId())
                 ->call('register');
 
             $this->assertDatabaseHas('users', ['email' => $data['email']]);
@@ -283,8 +285,8 @@ class EmailVerificationRateLimitTest extends TestCase
             ->set('state', $data['state'])
             ->set('zip_code', $data['zip_code'])
             ->set('country', $data['country'])
-            ->set('district_id', 'none')
-            ->set('fleet_id', 'none')
+            ->set('district_id', District::noneId())
+            ->set('fleet_id', Fleet::noneId())
             ->call('register')
             ->assertDispatched('toast');
 
@@ -330,8 +332,8 @@ class EmailVerificationRateLimitTest extends TestCase
                 ->set('state', $data['state'])
                 ->set('zip_code', $data['zip_code'])
                 ->set('country', $data['country'])
-                ->set('district_id', 'none')
-                ->set('fleet_id', 'none')
+                ->set('district_id', District::noneId())
+                ->set('fleet_id', Fleet::noneId())
                 ->call('register');
         }
 
@@ -361,8 +363,8 @@ class EmailVerificationRateLimitTest extends TestCase
             ->set('state', 'TS')
             ->set('zip_code', '12345')
             ->set('country', 'US')
-            ->set('district_id', 'none')
-            ->set('fleet_id', 'none')
+            ->set('district_id', District::noneId())
+            ->set('fleet_id', Fleet::noneId())
             ->call('register');
 
         // Get the newly created user

--- a/tests/Feature/EmailVerificationTest.php
+++ b/tests/Feature/EmailVerificationTest.php
@@ -5,6 +5,9 @@ namespace Tests\Feature;
 use App\Livewire\EmailVerificationBanner;
 use App\Livewire\ProfileForm;
 use App\Livewire\RegistrationForm;
+use App\Models\District;
+use App\Models\Fleet;
+use App\Models\Member;
 use App\Models\User;
 use App\Notifications\ResetPasswordNotification;
 use App\Notifications\VerifyEmailChange;
@@ -217,6 +220,14 @@ class EmailVerificationTest extends TestCase
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'email_verified_at' => now(),
+        ]);
+
+        // Profile saves require an affiliation (every registered user has one)
+        Member::create([
+            'user_id' => $user->id,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
+            'year' => now()->year,
         ]);
 
         Livewire::actingAs($user)

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -170,6 +170,36 @@ class ExportTest extends TestCase
         $this->assertStringContainsString('Mission Bay Fleet', $content);
     }
 
+    public function test_export_renders_none_affiliation_with_blank_fleet_number(): void
+    {
+        $user = User::factory()->create();
+
+        Member::create([
+            'user_id' => $user->id,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
+            'year' => 2024,
+        ]);
+
+        Flash::factory()->create([
+            'user_id' => $user->id,
+            'date' => '2024-06-15',
+            'activity_type' => 'sailing',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('export.user-data'));
+
+        $content = $response->streamedContent();
+        $flashRow = collect(explode('
+', $content))
+            ->first(fn ($line) => str_contains($line, '2024-06-15'));
+
+        $this->assertNotNull($flashRow);
+        // District/fleet names export honestly; the sentinel fleet_number 0 is
+        // blanked rather than exported as a fake fleet number
+        $this->assertStringContainsString('Unaffiliated/None,,None', $flashRow);
+    }
+
     public function test_export_handles_membership_changes_across_years(): void
     {
         // Create two districts and fleets

--- a/tests/Feature/LeaderboardTest.php
+++ b/tests/Feature/LeaderboardTest.php
@@ -177,8 +177,8 @@ class LeaderboardTest extends TestCase
         // Create unaffiliated membership (no district/fleet)
         Member::create([
             'user_id' => $user->id,
-            'district_id' => null,
-            'fleet_id' => null,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
             'year' => 2025,
         ]);
 
@@ -574,8 +574,8 @@ class LeaderboardTest extends TestCase
         // User 2 has no fleet
         Member::create([
             'user_id' => $user2->id,
-            'district_id' => null,
-            'fleet_id' => null,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
             'year' => 2025,
         ]);
 
@@ -719,8 +719,8 @@ class LeaderboardTest extends TestCase
         // User 2 has no district
         Member::create([
             'user_id' => $user2->id,
-            'district_id' => null,
-            'fleet_id' => null,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
             'year' => 2025,
         ]);
 

--- a/tests/Feature/LeaderboardTest.php
+++ b/tests/Feature/LeaderboardTest.php
@@ -598,6 +598,40 @@ class LeaderboardTest extends TestCase
         $response->assertDontSee('Bob Jones'); // User without fleet not shown
     }
 
+    public function test_grouped_tabs_exclude_users_whose_carried_forward_membership_is_none(): void
+    {
+        // Membership row exists only for a PRIOR year and points at the None
+        // rows; the target year resolves affiliation via carry-forward. The
+        // sentinel exclusion must hold on that path too: the sailor still
+        // ranks individually but neither grouped tab gains a None row.
+        $user = User::factory()->create(['first_name' => 'Carrie', 'last_name' => 'Forward']);
+
+        Member::create([
+            'user_id' => $user->id,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
+            'year' => 2024,
+        ]);
+
+        Flash::factory()->create([
+            'user_id' => $user->id,
+            'date' => '2025-06-01',
+            'activity_type' => 'sailing',
+        ]);
+
+        $this->get('/leaderboard?tab=sailor')
+            ->assertStatus(200)
+            ->assertSee('Carrie Forward');
+
+        $this->get('/leaderboard?tab=fleet')
+            ->assertStatus(200)
+            ->assertDontSee('Fleet 0');
+
+        $this->get('/leaderboard?tab=district')
+            ->assertStatus(200)
+            ->assertDontSee('Unaffiliated/None');
+    }
+
     public function test_district_tab_shows_district_rankings(): void
     {
         // Get districts from seeded data

--- a/tests/Feature/Livewire/ProfileFormTest.php
+++ b/tests/Feature/Livewire/ProfileFormTest.php
@@ -15,6 +15,23 @@ class ProfileFormTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * Profile saves require an affiliation; every registered user gets a
+     * membership row at registration, so tests mirror that invariant.
+     */
+    private function createUserWithNoneMembership(array $attributes = []): User
+    {
+        $user = User::factory()->create($attributes);
+        Member::create([
+            'user_id' => $user->id,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
+            'year' => now()->year,
+        ]);
+
+        return $user;
+    }
+
     public function test_component_renders_successfully(): void
     {
         $user = User::factory()->create();
@@ -92,7 +109,7 @@ class ProfileFormTest extends TestCase
 
     public function test_can_update_profile(): void
     {
-        $user = User::factory()->create([
+        $user = $this->createUserWithNoneMembership([
             'first_name' => 'John',
             'last_name' => 'Doe',
             'email' => 'john@example.com',
@@ -192,7 +209,7 @@ class ProfileFormTest extends TestCase
         Member::create([
             'user_id' => $user->id,
             'district_id' => $district->id,
-            'fleet_id' => null,
+            'fleet_id' => Fleet::noneId(),
             'year' => now()->year,
         ]);
 
@@ -207,23 +224,21 @@ class ProfileFormTest extends TestCase
             ->first();
 
         $this->assertEquals($district->id, $membership->district_id);
-        $this->assertNull($membership->fleet_id);
+        $this->assertEquals(Fleet::noneId(), $membership->fleet_id);
     }
 
     public function test_selecting_none_for_district_or_fleet_shows_no_live_validation_error(): void
     {
-        // Regression: the TomSelect UI sends the literal string 'none' for an
-        // explicit "Unaffiliated/None" pick, which only save() normalizes to
-        // null. The updated() live-validation hook ran validateOnly() with the
-        // base exists:... rules, so picking None instantly flagged the field
-        // with "The selected fleet id is invalid."
+        // Unaffiliated/None is a real district/fleet row, so picking it live-
+        // validates cleanly like any other selection (regression: the old
+        // 'none' sentinel was instantly flagged by the exists rule).
         $user = User::factory()->create();
 
         Livewire::actingAs($user)
             ->test(ProfileForm::class)
-            ->set('fleet_id', 'none')
+            ->set('fleet_id', (string) Fleet::noneId())
             ->assertHasNoErrors()
-            ->set('district_id', 'none')
+            ->set('district_id', (string) District::noneId())
             ->assertHasNoErrors();
     }
 
@@ -251,7 +266,7 @@ class ProfileFormTest extends TestCase
             ->set('fleet_id', null)
             ->call('save')
             ->assertHasErrors(['fleet_id'])
-            ->set('fleet_id', 'none')
+            ->set('fleet_id', (string) Fleet::noneId())
             ->assertHasNoErrors(['fleet_id']);
     }
 
@@ -380,7 +395,7 @@ class ProfileFormTest extends TestCase
 
     public function test_optional_fields_can_be_empty(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithNoneMembership();
 
         Livewire::actingAs($user)
             ->test(ProfileForm::class)
@@ -395,8 +410,6 @@ class ProfileFormTest extends TestCase
             ->set('state', $user->state)
             ->set('zip_code', $user->zip_code)
             ->set('country', $user->country)
-            ->set('district_id', null) // Optional
-            ->set('fleet_id', null) // Optional
             ->set('yacht_club', '') // Optional
             ->call('save')
             ->assertHasNoErrors();
@@ -446,7 +459,7 @@ class ProfileFormTest extends TestCase
 
     public function test_shows_success_toast_after_save(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithNoneMembership();
 
         Livewire::actingAs($user)
             ->test(ProfileForm::class)
@@ -496,7 +509,7 @@ class ProfileFormTest extends TestCase
 
     public function test_can_keep_same_email_when_updating_profile(): void
     {
-        $user = User::factory()->create([
+        $user = $this->createUserWithNoneMembership([
             'email' => 'john@example.com',
         ]);
 

--- a/tests/Feature/Livewire/ProfileFormTest.php
+++ b/tests/Feature/Livewire/ProfileFormTest.php
@@ -195,7 +195,7 @@ class ProfileFormTest extends TestCase
         $this->assertEquals($fleet2->id, $membership->fleet_id);
     }
 
-    public function test_no_change_save_with_district_and_no_fleet_does_not_demand_fleet(): void
+    public function test_no_change_save_with_district_and_none_fleet_saves_cleanly(): void
     {
         // Regression: on profile-page load the TomSelect init re-syncs the
         // district to Livewire as a STRING (HTML select values are strings)

--- a/tests/Feature/RegistrationWithMembershipsTest.php
+++ b/tests/Feature/RegistrationWithMembershipsTest.php
@@ -80,8 +80,8 @@ class RegistrationWithMembershipsTest extends TestCase
     {
         $data = array_merge($this->getBaseRegistrationData(), [
             'gender' => 'female',
-            'district_id' => 'none', // Livewire converts 'none' to 0
-            'fleet_id' => 'none',
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
         ]);
 
         Livewire::test(RegistrationForm::class)
@@ -100,8 +100,8 @@ class RegistrationWithMembershipsTest extends TestCase
             ->first();
 
         $this->assertNotNull($membership);
-        $this->assertNull($membership->district_id);
-        $this->assertNull($membership->fleet_id);
+        $this->assertEquals(District::noneId(), $membership->district_id);
+        $this->assertEquals(Fleet::noneId(), $membership->fleet_id);
     }
 
     public function test_user_can_register_with_only_district(): void
@@ -111,7 +111,7 @@ class RegistrationWithMembershipsTest extends TestCase
         $data = array_merge($this->getBaseRegistrationData(), [
             'gender' => 'non_binary',
             'district_id' => $district->id,
-            'fleet_id' => 'none',
+            'fleet_id' => Fleet::noneId(),
         ]);
 
         Livewire::test(RegistrationForm::class)
@@ -123,18 +123,18 @@ class RegistrationWithMembershipsTest extends TestCase
         $membership = $user->currentMembership();
 
         $this->assertEquals($district->id, $membership->district_id);
-        $this->assertNull($membership->fleet_id);
+        $this->assertEquals(Fleet::noneId(), $membership->fleet_id);
     }
 
     public function test_registration_rejects_a_fleet_without_a_district(): void
     {
-        // Every fleet belongs to a district, so a fleet with no district selected
-        // is invalid and must be rejected.
-        $fleet = Fleet::first();
+        // A real fleet must belong to the *selected* district — pairing one
+        // with the Unaffiliated/None district is invalid.
+        $fleet = Fleet::where('fleet_number', '!=', Fleet::NONE_NUMBER)->firstOrFail();
 
         $data = array_merge($this->getBaseRegistrationData(), [
             'gender' => 'prefer_not_to_say',
-            'district_id' => 'none',
+            'district_id' => District::noneId(),
             'fleet_id' => $fleet->id,
         ]);
 
@@ -150,7 +150,7 @@ class RegistrationWithMembershipsTest extends TestCase
     public function test_registration_rejects_a_fleet_from_a_different_district(): void
     {
         // The fleet must belong to the *selected* district, not just exist.
-        $fleet = Fleet::first();
+        $fleet = Fleet::where('fleet_number', '!=', Fleet::NONE_NUMBER)->firstOrFail();
         $otherDistrict = District::where('id', '!=', $fleet->district_id)->firstOrFail();
 
         $data = array_merge($this->getBaseRegistrationData(), [
@@ -172,7 +172,7 @@ class RegistrationWithMembershipsTest extends TestCase
     {
         $data = array_merge($this->getBaseRegistrationData(), [
             'district_id' => 99999, // Invalid ID
-            'fleet_id' => 'none',
+            'fleet_id' => Fleet::noneId(),
         ]);
 
         Livewire::test(RegistrationForm::class)
@@ -225,8 +225,8 @@ class RegistrationWithMembershipsTest extends TestCase
     public function test_user_without_district_or_fleet_still_creates_membership(): void
     {
         $data = array_merge($this->getBaseRegistrationData(), [
-            'district_id' => 'none',
-            'fleet_id' => 'none',
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
         ]);
 
         Livewire::test(RegistrationForm::class)
@@ -237,8 +237,8 @@ class RegistrationWithMembershipsTest extends TestCase
 
         // Should create membership record even for unaffiliated users
         $this->assertEquals(1, $user->members()->count());
-        $this->assertNull($user->currentMembership()->district_id);
-        $this->assertNull($user->currentMembership()->fleet_id);
+        $this->assertEquals(District::noneId(), $user->currentMembership()->district_id);
+        $this->assertEquals(Fleet::noneId(), $user->currentMembership()->fleet_id);
     }
 
     public function test_registration_does_not_store_district_or_fleet_on_user_table(): void

--- a/tests/Feature/SailorLogsTest.php
+++ b/tests/Feature/SailorLogsTest.php
@@ -235,6 +235,49 @@ class SailorLogsTest extends TestCase
         $component->assertSee('Next');
     }
 
+    public function test_csv_export_renders_none_fleet_as_dash_not_zero(): void
+    {
+        // Regression: the None fleet's fleet_number is 0 (non-null), so the
+        // old `?? '—'` fallback let a literal 0 through into the CSV.
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $user = User::factory()->create([
+            'first_name' => 'Unaff',
+            'last_name' => 'Iliated',
+        ]);
+
+        Member::factory()->create([
+            'user_id' => $user->id,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
+            'year' => now()->year,
+        ]);
+
+        Flash::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->startOfYear()->addDays(1),
+            'activity_type' => 'sailing',
+            'event_type' => 'regatta',
+        ]);
+
+        $response = Livewire::actingAs($admin)
+            ->test('sailor-logs')
+            ->call('exportCsv')
+            ->assertSuccessful();
+
+        $content = $response->effects['download']['content'];
+        if (base64_encode(base64_decode($content, true)) === $content) {
+            $content = base64_decode($content);
+        }
+
+        $row = collect(explode("\n", $content))
+            ->first(fn ($line) => str_contains($line, 'Unaff Iliated'));
+
+        $this->assertNotNull($row);
+        // District name exports honestly; fleet_number 0 renders as a dash
+        $this->assertStringContainsString('Unaffiliated/None,—', $row);
+    }
+
     public function test_csv_export_includes_correct_data(): void
     {
         $admin = User::factory()->create(['is_admin' => true]);

--- a/tests/Unit/MemberTest.php
+++ b/tests/Unit/MemberTest.php
@@ -232,7 +232,6 @@ class MemberTest extends TestCase
         // behavior now blocks deleting a district that still has members
         $this->expectException(QueryException::class);
         $district->delete();
-        $this->assertNull($member->fleet_id); // Fleet was deleted, so also set to null
     }
 
     public function test_deleting_fleet_with_member_records_is_blocked(): void

--- a/tests/Unit/MemberTest.php
+++ b/tests/Unit/MemberTest.php
@@ -75,19 +75,21 @@ class MemberTest extends TestCase
 
     public function test_member_can_be_unaffiliated(): void
     {
+        // Unaffiliated = the sentinel None district/fleet rows; the columns
+        // are NOT NULL (see make_none_a_real_district_and_fleet migration)
         $user = User::factory()->create();
 
         $member = Member::create([
             'user_id' => $user->id,
-            'district_id' => null,
-            'fleet_id' => null,
+            'district_id' => District::noneId(),
+            'fleet_id' => Fleet::noneId(),
             'year' => 2025,
         ]);
 
-        $this->assertNull($member->district_id);
-        $this->assertNull($member->fleet_id);
-        $this->assertNull($member->district);
-        $this->assertNull($member->fleet);
+        $this->assertSame(District::noneId(), $member->district_id);
+        $this->assertSame(Fleet::noneId(), $member->fleet_id);
+        $this->assertSame(District::NONE_NAME, $member->district->name);
+        $this->assertSame(Fleet::NONE_NUMBER, $member->fleet->fleet_number);
     }
 
     public function test_user_can_have_multiple_memberships_across_years(): void
@@ -213,46 +215,42 @@ class MemberTest extends TestCase
         $this->assertDatabaseMissing('members', ['id' => $memberId]);
     }
 
-    public function test_deleting_district_cascades_to_fleets_and_nullifies_member_records(): void
+    public function test_deleting_district_with_member_records_is_blocked(): void
     {
         $user = User::factory()->create();
         $district = District::first();
         $fleet = Fleet::where('district_id', $district->id)->first();
 
-        $member = Member::create([
+        Member::create([
             'user_id' => $user->id,
             'district_id' => $district->id,
             'fleet_id' => $fleet->id,
             'year' => 2025,
         ]);
 
-        // Deleting district cascades to delete its fleets
-        // This triggers onDelete('set null') on members table for both district_id and fleet_id
+        // members.district_id is NOT NULL, so the old onDelete('set null')
+        // behavior now blocks deleting a district that still has members
+        $this->expectException(QueryException::class);
         $district->delete();
-
-        $member->refresh();
-        $this->assertNull($member->district_id);
         $this->assertNull($member->fleet_id); // Fleet was deleted, so also set to null
     }
 
-    public function test_deleting_fleet_sets_fleet_id_to_null(): void
+    public function test_deleting_fleet_with_member_records_is_blocked(): void
     {
         $user = User::factory()->create();
         $district = District::first();
         $fleet = Fleet::first();
 
-        $member = Member::create([
+        Member::create([
             'user_id' => $user->id,
             'district_id' => $district->id,
             'fleet_id' => $fleet->id,
             'year' => 2025,
         ]);
 
+        // members.fleet_id is NOT NULL, so deleting a referenced fleet is blocked
+        $this->expectException(QueryException::class);
         $fleet->delete();
-
-        $member->refresh();
-        $this->assertNull($member->fleet_id);
-        $this->assertNotNull($member->district_id); // District should remain
     }
 
     public function test_user_can_have_different_memberships_for_different_years(): void

--- a/tests/Unit/MemberTest.php
+++ b/tests/Unit/MemberTest.php
@@ -25,8 +25,8 @@ class MemberTest extends TestCase
     public function test_member_belongs_to_user(): void
     {
         $user = User::factory()->create();
-        $district = District::first();
-        $fleet = Fleet::first();
+        $district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
+        $fleet = Fleet::where('fleet_number', '!=', Fleet::NONE_NUMBER)->firstOrFail();
 
         $member = Member::create([
             'user_id' => $user->id,
@@ -218,8 +218,8 @@ class MemberTest extends TestCase
     public function test_deleting_district_with_member_records_is_blocked(): void
     {
         $user = User::factory()->create();
-        $district = District::first();
-        $fleet = Fleet::where('district_id', $district->id)->first();
+        $district = District::where('name', '!=', District::NONE_NAME)->firstOrFail();
+        $fleet = Fleet::where('district_id', $district->id)->firstOrFail();
 
         Member::create([
             'user_id' => $user->id,

--- a/tests/js/district-fleet-select.test.js
+++ b/tests/js/district-fleet-select.test.js
@@ -334,18 +334,21 @@ describe('District and Fleet TomSelect Integration', () => {
             expect(onDistrictChangeSpy).toHaveBeenCalledWith('1');
         });
 
-        it('should call onDistrictChange with "none" when "none" is selected', async () => {
+        it('should sync the None district id and offer all fleets when Unaffiliated/None is selected', async () => {
             const result = await initializeDistrictFleetSelects({
                 districtSelectId: 'district-select',
                 fleetSelectId: 'fleet-select',
                 onDistrictChange: onDistrictChangeSpy
             });
 
-            result.districtTomSelect.options.onChange.call(result.districtTomSelect, 'none');
+            result.fleetTomSelect.addOption.mockClear();
+            result.districtTomSelect.options.onChange.call(result.districtTomSelect, '99');
 
-            // 'none' is sent literally for explicit "Unaffiliated" so the server
-            // can distinguish it from a cleared/empty district.
-            expect(onDistrictChangeSpy).toHaveBeenCalledWith('none');
+            // The None district is a real row; its id syncs like any other pick,
+            // and every fleet stays selectable (picking one auto-sets its district)
+            expect(onDistrictChangeSpy).toHaveBeenCalledWith('99');
+            const added = result.fleetTomSelect.addOption.mock.calls.map(c => c[0]);
+            expect(added.length).toBe(mockFleets.length);
         });
     });
 

--- a/tests/js/district-fleet-select.test.js
+++ b/tests/js/district-fleet-select.test.js
@@ -56,15 +56,19 @@ describe('District and Fleet TomSelect Integration', () => {
 
     beforeEach(() => {
         // Setup mock data
+        // Unaffiliated/None is a real district (id 99) and fleet (id 90,
+        // fleet_number 0); the API reports their ids alongside the lists
         mockDistricts = [
             { id: 1, name: 'District 1' },
-            { id: 2, name: 'District 2' }
+            { id: 2, name: 'District 2' },
+            { id: 99, name: 'Unaffiliated/None' }
         ];
 
         mockFleets = [
             { id: 1, fleet_number: '1', fleet_name: 'Fleet One', district_id: 1, district_name: 'District 1' },
             { id: 2, fleet_number: '2', fleet_name: 'Fleet Two', district_id: 1, district_name: 'District 1' },
-            { id: 3, fleet_number: '3', fleet_name: 'Fleet Three', district_id: 2, district_name: 'District 2' }
+            { id: 3, fleet_number: '3', fleet_name: 'Fleet Three', district_id: 2, district_name: 'District 2' },
+            { id: 90, fleet_number: 0, fleet_name: 'None', district_id: 99, district_name: 'Unaffiliated/None' }
         ];
 
         // Mock fetch response
@@ -72,7 +76,9 @@ describe('District and Fleet TomSelect Integration', () => {
             ok: true,
             json: async () => ({
                 districts: mockDistricts,
-                fleets: mockFleets
+                fleets: mockFleets,
+                none_district_id: 99,
+                none_fleet_id: 90
             })
         });
 
@@ -116,27 +122,27 @@ describe('District and Fleet TomSelect Integration', () => {
             expect(result.fleetTomSelect).toBeDefined();
         });
 
-        it('should add "none" option to district select', async () => {
+        it('should include the Unaffiliated/None district from the API data', async () => {
             const result = await initializeDistrictFleetSelects({
                 districtSelectId: 'district-select',
                 fleetSelectId: 'fleet-select'
             });
 
             const districtOptions = result.districtTomSelect.optionsList;
-            const noneOption = districtOptions.find(opt => opt.value === 'none');
+            const noneOption = districtOptions.find(opt => opt.value === 99);
 
             expect(noneOption).toBeDefined();
             expect(noneOption.text).toBe('Unaffiliated/None');
         });
 
-        it('should add "none" option to fleet select', async () => {
+        it('should label the None fleet row "None"', async () => {
             const result = await initializeDistrictFleetSelects({
                 districtSelectId: 'district-select',
                 fleetSelectId: 'fleet-select'
             });
 
             const fleetOptions = result.fleetTomSelect.optionsList;
-            const noneOption = fleetOptions.find(opt => opt.value === 'none');
+            const noneOption = fleetOptions.find(opt => opt.value === 90);
 
             expect(noneOption).toBeDefined();
             expect(noneOption.text).toBe('None');
@@ -149,7 +155,7 @@ describe('District and Fleet TomSelect Integration', () => {
             fleetSelect.dataset.isProfile = 'true';
         });
 
-        it('should set district to "none" when value is null on profile page', async () => {
+        it('should fall back to the None district when value is empty on profile page', async () => {
             districtSelect.dataset.value = '';
 
             const result = await initializeDistrictFleetSelects({
@@ -157,10 +163,11 @@ describe('District and Fleet TomSelect Integration', () => {
                 fleetSelectId: 'fleet-select'
             });
 
-            expect(result.districtTomSelect.setValue).toHaveBeenCalledWith('none', true);
+            // Non-silent so the Livewire property stays in sync with the UI
+            expect(result.districtTomSelect.setValue).toHaveBeenCalledWith('99');
         });
 
-        it('should set fleet to "none" when value is null on profile page', async () => {
+        it('should fall back to the None fleet when value is empty on profile page', async () => {
             fleetSelect.dataset.value = '';
 
             const result = await initializeDistrictFleetSelects({
@@ -168,7 +175,7 @@ describe('District and Fleet TomSelect Integration', () => {
                 fleetSelectId: 'fleet-select'
             });
 
-            expect(result.fleetTomSelect.setValue).toHaveBeenCalledWith('none', true);
+            expect(result.fleetTomSelect.setValue).toHaveBeenCalledWith('90');
         });
 
         it('should preserve existing district value on profile page', async () => {
@@ -204,9 +211,9 @@ describe('District and Fleet TomSelect Integration', () => {
                 fleetSelectId: 'fleet-select'
             });
 
-            // Should not call setValue with 'none' for empty values on signup
+            // Should not fall back to the None district for empty values on signup
             const setValueCalls = result.districtTomSelect.setValue.mock.calls;
-            const noneCall = setValueCalls.find(call => call[0] === 'none');
+            const noneCall = setValueCalls.find(call => call[0] === '99');
             expect(noneCall).toBeUndefined();
         });
 
@@ -219,15 +226,15 @@ describe('District and Fleet TomSelect Integration', () => {
                 fleetSelectId: 'fleet-select'
             });
 
-            // Should not call setValue with 'none' for empty values on signup
+            // Should not fall back to the None fleet for empty values on signup
             const setValueCalls = result.fleetTomSelect.setValue.mock.calls;
-            const noneCall = setValueCalls.find(call => call[0] === 'none');
+            const noneCall = setValueCalls.find(call => call[0] === '90');
             expect(noneCall).toBeUndefined();
         });
     });
 
     describe('Special Case: Auto-populate District when Fleet is None', () => {
-        it('should set district to "none" when fleet is set to "none" and district is empty', async () => {
+        it('should set district to None when fleet is set to None and district is empty', async () => {
             const result = await initializeDistrictFleetSelects({
                 districtSelectId: 'district-select',
                 fleetSelectId: 'fleet-select',
@@ -235,14 +242,15 @@ describe('District and Fleet TomSelect Integration', () => {
                 onFleetChange: onFleetChangeSpy
             });
 
-            // Simulate user selecting 'none' for fleet when district is empty
+            // Simulate user selecting the None fleet when district is empty
             result.districtTomSelect.getValue.mockReturnValue('');
-            result.fleetTomSelect.options.onChange.call(result.fleetTomSelect, 'none');
+            result.fleetTomSelect.options.onChange.call(result.fleetTomSelect, '90');
 
-            expect(result.districtTomSelect.setValue).toHaveBeenCalledWith('none', true);
+            expect(result.districtTomSelect.setValue).toHaveBeenCalledWith('99', true);
+            expect(onDistrictChangeSpy).toHaveBeenCalledWith('99');
         });
 
-        it('should NOT change district when fleet is set to "none" and district already has a value', async () => {
+        it('should NOT change district when fleet is set to None and district already has a value', async () => {
             const result = await initializeDistrictFleetSelects({
                 districtSelectId: 'district-select',
                 fleetSelectId: 'fleet-select'
@@ -254,14 +262,14 @@ describe('District and Fleet TomSelect Integration', () => {
             // Clear previous setValue calls
             result.districtTomSelect.setValue.mockClear();
 
-            // Simulate user selecting 'none' for fleet
-            result.fleetTomSelect.options.onChange.call(result.fleetTomSelect, 'none');
+            // Simulate user selecting the None fleet
+            result.fleetTomSelect.options.onChange.call(result.fleetTomSelect, '90');
 
             // Should NOT call setValue on district since it already has a value
             expect(result.districtTomSelect.setValue).not.toHaveBeenCalled();
         });
 
-        it('should call onFleetChange with "none" when fleet is set to "none"', async () => {
+        it('should call onFleetChange with the None fleet id when fleet is set to None', async () => {
             const result = await initializeDistrictFleetSelects({
                 districtSelectId: 'district-select',
                 fleetSelectId: 'fleet-select',
@@ -269,11 +277,12 @@ describe('District and Fleet TomSelect Integration', () => {
             });
 
             result.districtTomSelect.getValue.mockReturnValue('');
-            result.fleetTomSelect.options.onChange.call(result.fleetTomSelect, 'none');
+            result.fleetTomSelect.options.onChange.call(result.fleetTomSelect, '90');
 
-            // 'none' is sent literally so the server can distinguish an explicit
-            // "Unaffiliated/None" choice from an untouched/auto-cleared field.
-            expect(onFleetChangeSpy).toHaveBeenCalledWith('none');
+            // The real None fleet id syncs like any other pick; the server
+            // distinguishes an explicit choice from an auto-cleared field by
+            // the value being non-empty.
+            expect(onFleetChangeSpy).toHaveBeenCalledWith('90');
         });
     });
 
@@ -293,12 +302,13 @@ describe('District and Fleet TomSelect Integration', () => {
 
             expect(result.fleetTomSelect.clearOptions).toHaveBeenCalled();
 
-            // Should add only fleets from District 1
+            // Should add District 1's fleets plus the always-available None fleet
             const addedOptions = result.fleetTomSelect.addOption.mock.calls.map(call => call[0]);
-            const fleetOptions = addedOptions.filter(opt => opt.value !== 'none');
+            const realFleets = addedOptions.filter(opt => opt.value !== 90);
 
-            expect(fleetOptions.length).toBe(2); // Fleet 1 and Fleet 2
-            expect(fleetOptions.every(opt => opt.district_id === 1)).toBe(true);
+            expect(realFleets.length).toBe(2); // Fleet 1 and Fleet 2
+            expect(realFleets.every(opt => opt.district_id === 1)).toBe(true);
+            expect(addedOptions.some(opt => opt.value === 90)).toBe(true);
         });
 
         it('should clear fleet selection when district changes', async () => {


### PR DESCRIPTION
## Summary

The nullable `members.district_id`/`fleet_id` columns forced a three-way sentinel dance through the profile and registration forms — the `'none'` string from the UI vs `null` vs untouched — and produced a string of validation bugs (spurious "Please select a fleet", instant "The selected fleet id is invalid" on picking None, stale errors that wouldn't clear). This makes **Unaffiliated/None a real district row and a real fleet row**, so it validates, stores, and displays like any other selection.

## Changes

- **Migration** (`make_none_a_real_district_and_fleet`): creates the `Unaffiliated/None` district and `None` fleet (`fleet_number 0`, selectable alongside any district), backfills null member affiliations, then makes both member columns **NOT NULL**. Verified up *and* rollback against a live DB copy (`PRAGMA` checks clean). Production currently has **6 members with a NULL fleet_id** (districts set); the backfill converts them to the None fleet — semantically identical to their current state, and exactly the district-member-without-fleet case covered by the form/leaderboard tests. Consequence: deleting a district/fleet that still has members is now blocked (was set-null, which contradicted NOT NULL).
- **`District::noneId()` / `Fleet::noneId()`** helpers + `NONE_NAME`/`NONE_NUMBER` constants; the `districts-and-fleets` API reports the sentinel ids so the frontend stops string-matching.
- **Forms**: `ProfileForm.save()` loses the entire `fleetRaw`/district-changed/null-normalization machinery — both forms now share identical explicit-selection validation closures, and a None pick live-validates (and clears stale errors) like any real row. The None fleet is valid with ANY district; a real fleet must still match the selected district. `UserDataService::normalizeAffiliationIds()` deleted.
- **JS** (`district-fleet-select.js`): synthetic `'none'` options removed — the rows come from the API payload; the None fleet is offered under every district (sorts first via `fleet_number 0`).
- **Leaderboards**: fleet/district tabs exclude the sentinel rows explicitly (previously unaffiliated users fell out of inner joins by accident); sailor tab and admin/CSV displays render None affiliations as `—`.

## Verification

- Full PHP suite: **456 passed** (28 tests initially broke; all updated for the new invariants — null-member creations, the `'none'` sentinel across six files, delete-behavior expectations)
- Browser suites green: profile district/fleet flows (None save + reload round-trip, district-change auto-clear blocking, error clearing) and full registration flows — real TomSelect interactions, not simulations
- JS unit tests: 22/22 (vitest)
- Migration exercised against a copy of the live dev database, both directions

## Deploy note

On release to `main`, the migration applies itself to production within a poll cycle (entrypoint runs `migrate --force`). The backfill updates the 6 NULL-fleet members to the None fleet; the schema tightening rebuilds the `members` table (SQLite), which is small. The 02:00 daily backup is the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
