### PR TITLE
fix(deploy): give the container 30s to stop (fixes Synology "stopped unexpectedly")

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -58,14 +58,18 @@ for d in "$DATA_DIR/data" "$DATA_DIR/logs" "$DATA_DIR/backup"; do
 done
 
 echo "$(date -u +%FT%TZ) recreating $CONTAINER on :$PORT from $IMAGE"
-# Graceful stop first (SIGTERM -> supervisord clean shutdown) so Synology's
-# Container Manager doesn't report a "stopped unexpectedly" (which a SIGKILL
-# from `rm -f` on a running container triggers). rm -f then just removes the
-# already-stopped container.
-docker stop "$CONTAINER" >/dev/null 2>&1 || true
+# Graceful stop first (SIGTERM -> supervisord shuts its children down and exits
+# 0) so Synology's Container Manager doesn't report "stopped unexpectedly" (a
+# SIGKILL exit, 137). The -t 30 is load-bearing: supervisord's orderly shutdown
+# takes ~2s, but the container's default stop grace is only ~1s, so the stock
+# `docker stop` SIGKILLs it mid-shutdown. rm -f then removes the stopped container.
+docker stop -t 30 "$CONTAINER" >/dev/null 2>&1 || true
 docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
 docker run -d --name "$CONTAINER" --restart unless-stopped \
     `# no --cpus: DSM kernels lack the CFS scheduler` \
+    `# --stop-timeout 30: bake the grace into the container so a stop from the` \
+    `# Synology GUI (or any bare 'docker stop') also gets a clean exit 0, not 137` \
+    --stop-timeout 30 \
     -p "$PORT:8080" \
     -v "$DATA_DIR/data:/var/www/html/database/data" \
     -v "$DATA_DIR/logs:/var/www/html/storage/logs" \


### PR DESCRIPTION
## Problem

Synology Container Manager pops **"Container gotflashes stopped unexpectedly"** on every deploy (and on a GUI stop). The container was exiting **137** (SIGKILL) on stop.

## Root cause

Not a signal-handling bug — purely the **stop grace period**. The container's effective stop grace was **~1 second** (`Config.StopTimeout`), but supervisord's orderly shutdown (SIGQUIT → stop php-fpm/nginx/queue-worker/scheduler → exit 0) takes **~2 seconds**. So `docker stop` SIGKILLed supervisord mid-shutdown → exit 137 → the Synology alert.

Diagnosis (all reproduced locally against the prod image):
- stock grace → **exit 137, 5/5 trials** (`docker stop` returns in ~1.3s)
- `--stop-timeout 30` / `docker stop -t 30` → **exit 0, ~2s**, children log clean `exit status 0`
- a manual `SIGTERM` to PID 1 also exits 0 — confirming the shutdown path itself is fine, it just needs the time

Investigated and ruled out adding `tini`/an init: the existing supervisord-as-PID-1 shuts down cleanly given adequate grace (the original no-tini image exits 0 with `--stop-timeout 30`), so no image change is warranted — `StopTimeout` can't be baked into an image anyway (no Dockerfile instruction for it).

## Fix (`deploy/deploy.sh` only)

- `docker run --stop-timeout 30` — bakes the grace into the container so a stop from the **Synology GUI** (or any bare `docker stop`) also exits 0.
- `docker stop -t 30` — explicit grace on the deploy path's own pre-recreate stop.

## Verification

Drove the exact `docker run … --stop-timeout 30` / `docker stop -t 30` sequence deploy.sh uses: exit 0 across multiple trials; app health-check 200 before each stop.

This only changes host-side deploy tooling — no app/image change, so nothing to release; it takes effect on the next host deploy after the scripts are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)