### PR TITLE
Release: public community stats page (/stats) + super_admin role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ tests/Browser/Screenshots/
 # Windows "Mark of the Web" alternate-data-stream artifacts (appear on WSL when
 # files are copied/downloaded via Windows, e.g. nginx-access.log:Zone.Identifier)
 *:Zone.Identifier
+
+# 2025 season report drop (contains member PII — never commit)
+/Report *.xlsx
+
+# Playwright MCP screenshot/artifact output
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,10 @@ Routes in `routes/web.php`:
 - `/profile` - View/edit profile - auth required
 - `/export/user-data` - CSV export of profile + activity - auth required
 - `/leaderboard` - Public leaderboard with three tabs: sailor, fleet, district
+- `/stats` - Public community statistics page (lightning goal fill-up + D3 charts)
 - `/password/*`, `/verify-email/{token}` - Password reset and email verification
-- `/admin/fulfillment`, `/admin/sailor-logs` - Admin dashboards - auth + admin required
+- `/admin/fulfillment`, `/admin/sailor-logs` - Award-admin dashboards - auth + `admin` (`is_admin`) required
+- `/admin/settings` - Site settings (community goal) - auth + `super_admin` (`is_super_admin`, elevated tier) required
 
 ### Frontend Architecture
 
@@ -177,6 +179,14 @@ Routes in `routes/web.php`:
   - URL query parameter support via `#[Url]` attribute for bookmarking
   - Pagination resets automatically when switching tabs
   - Uses Livewire pagination theme for consistent styling
+- **CommunityStats** (`app/Livewire/CommunityStats.php`): Public `/stats` page
+  - Aggregates per year (15-min `Cache::remember`, key `community-stats-{year}`): key counters, monthly/heatmap/event-mix/signups/age/funnel chart data, fun facts
+  - Reuses the leaderboard's capped-qualifying-count + membership carry-forward SQL patterns; excludes the sentinel None fleet/district from group counts
+  - Chart data flows to D3 (`resources/js/stats-charts.js`) via a JSON script tag on load and the `community-stats-updated` browser event on year change; chart containers sit in `wire:ignore`
+  - Lightning goal fill-up hero: `<x-lightning-fill :percentage>` (CSS clip-path keyframe animation, no Alpine — CSP has no `unsafe-eval`); goal stored via `Setting::get("community_goal_{year}")`
+  - Every chart has a server-rendered `<details>` data-table twin (accessibility + no hover-gated values)
+- **AdminSettings** (`app/Livewire/AdminSettings.php`): `/admin/settings`, extends `AdminComponent`
+  - Sets the per-year community goal (`settings` table via `App\Models\Setting` key-value helpers); saving clears that year's stats cache
 
 **Multi-Date Picker** (`resources/js/multi-date-picker.js`):
 - Uses flatpickr for date selection with multiple date support
@@ -395,6 +405,7 @@ This allows tracking of:
   - Filtering and search capabilities
   - Admin action logging
 - ✅ Automated daily SQLite database backups (validated, WAL-aware, 90-day retention, logged to `backup` channel)
+- ✅ Public community stats page (`/stats`, issue #33): lightning goal fill-up hero (configurable default goal, site-admin override at `/admin/settings`), key counters, five D3 charts (activity heatmap, flashes over the season, community growth, sailor ages, award funnel), fun facts; undisclosed gender / unknown age redistributed into displayed groups
 
 **Planned:**
 - 📋 Historical year views (read-only previous years)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ The G.O.T. Flashes Challenge encourages Lightning Class sailors to get on the wa
 ![Multi-Date Calendar Picker](docs/screenshots/datepicker.png)
 *Select multiple dates at once with existing entries marked*
 
+### Community Statistics
+![Community Statistics](docs/screenshots/stats.jpg)
+*Public dashboard: community-goal progress, activity heatmap, growth and season charts, and fun facts*
+
 ### Award Fulfillment Dashboard (Admin)
 ![Award Fulfillment Dashboard](docs/screenshots/fulfillment.png)
 *Admin interface for managing physical award mailings with batch operations and CSV export*
@@ -78,6 +82,12 @@ The G.O.T. Flashes Challenge encourages Lightning Class sailors to get on the wa
   - **Sailor**: Individual rankings by total flashes with year-specific memberships
   - **Fleet**: Fleet-level rankings with member counts
   - **District**: District-level rankings with member counts
+- **Community Statistics** (Public `/stats`): Class-wide participation dashboard
+  - Animated "lightning fill-up" progress toward the year's community goal (a configurable default, overridable per year by a site admin) with a prior-year benchmark line
+  - Headline counters plus five self-hosted D3 charts: activity heatmap, flashes over the season (filter by activity type / gender / age, count or share), community growth by age or gender, sailor ages, and a sign-up→award funnel
+  - Privacy-preserving: only community-level aggregates are shown, and undisclosed gender / unknown age are redistributed into the displayed groups so no individual can be singled out
+  - Fun facts (season opener, longest sailing streak, and more) with all tied sailors credited
+  - Every chart has an accessible, hover-free data-table twin; aggregates cached per year for fast public loads
 - **User Authentication**: Secure registration, login, password reset, and email verification system
   - Soft email verification - new users can immediately use the app without verifying
   - Persistent verification reminder banner for unverified accounts
@@ -160,11 +170,12 @@ php artisan tinker
 Then in the Tinker REPL:
 ```php
 $user = User::where('email', 'user@example.com')->first();
-$user->is_admin = true;
+$user->is_admin = true;        // award administration (fulfillment, sailor logs)
+$user->is_super_admin = true;  // elevated site-operator tier (site settings)
 $user->save();
 ```
 
-Press `Ctrl+C` to exit Tinker.
+`is_admin` and `is_super_admin` are independent — grant `is_super_admin` to access `/admin/settings` (the community goal). Press `Ctrl+C` to exit Tinker.
 
 **Security Note:** Only grant admin access to trusted users. Admins can:
 - View all user addresses and contact information

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -31,6 +31,11 @@ class SitemapController extends Controller
                 'changefreq' => 'daily',
                 'priority' => '0.9',
             ],
+            [
+                'loc' => $baseUrl.'/stats',
+                'changefreq' => 'daily',
+                'priority' => '0.9',
+            ],
         ];
 
         $sitemap = view('sitemap', ['urls' => $urls])->render();

--- a/app/Http/Middleware/SuperAdminMiddleware.php
+++ b/app/Http/Middleware/SuperAdminMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Support\SecurityLog;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SuperAdminMiddleware
+{
+    /**
+     * Gate site-operator routes (site settings; operational views).
+     * Requires the elevated `is_super_admin` flag, above the award-admin
+     * `is_admin` checked by AdminMiddleware.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user() || ! $request->user()->isSuperAdmin()) {
+            // Log denied access so probing of the site-admin area is visible.
+            SecurityLog::warning('super_admin_access_denied', 'Site admin access denied', [
+                'user_id' => $request->user()?->id,
+                'email' => $request->user()?->email,
+                'path' => $request->path(),
+            ]);
+
+            abort(403, 'Unauthorized. Site admin access required.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/AdminComponent.php
+++ b/app/Livewire/AdminComponent.php
@@ -19,8 +19,17 @@ abstract class AdminComponent extends Component
 
     public function mount(): void
     {
-        $this->authorizeAdmin();
+        $this->authorizeAccess();
         $this->initializeYear();
+    }
+
+    /**
+     * Access gate for the component. Defaults to award-admin; subclasses that
+     * need the elevated site-operator tier override this (see AdminSettings).
+     */
+    protected function authorizeAccess(): void
+    {
+        $this->authorizeAdmin();
     }
 
     /**
@@ -31,6 +40,17 @@ abstract class AdminComponent extends Component
     {
         if (! auth()->check() || ! auth()->user()->is_admin) {
             abort(403, 'Unauthorized. Admin access required.');
+        }
+    }
+
+    /**
+     * Ensure the current user holds the elevated site-operator tier.
+     * Aborts with 403 if not authenticated or not a super admin.
+     */
+    protected function authorizeSuperAdmin(): void
+    {
+        if (! auth()->check() || ! auth()->user()->isSuperAdmin()) {
+            abort(403, 'Unauthorized. Site admin access required.');
         }
     }
 

--- a/app/Livewire/AdminSettings.php
+++ b/app/Livewire/AdminSettings.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Setting;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Admin page for per-year community settings — currently the annual
+ * community sailing-days goal shown on the public /stats page.
+ */
+class AdminSettings extends AdminComponent
+{
+    public ?int $goal = null;
+
+    public function mount(): void
+    {
+        parent::mount();
+        $this->loadGoal();
+    }
+
+    // Site settings require the elevated site-operator tier, not just award-admin.
+    protected function authorizeAccess(): void
+    {
+        $this->authorizeSuperAdmin();
+    }
+
+    public function updatedSelectedYear(): void
+    {
+        $this->loadGoal();
+    }
+
+    public function save(): void
+    {
+        $this->validate([
+            'goal' => ['nullable', 'integer', 'min:1', 'max:1000000'],
+        ]);
+
+        Setting::set(
+            "community_goal_{$this->selectedYear}",
+            $this->goal !== null ? (string) $this->goal : null
+        );
+
+        // The public stats page caches per year; show the new goal immediately
+        CommunityStats::clearCache($this->selectedYear);
+
+        $this->dispatch('toast', type: 'success', message: "Community goal for {$this->selectedYear} saved.");
+    }
+
+    public function render()
+    {
+        $prior = $this->selectedYear - 1;
+        $historical = config('community.historical_totals', []);
+
+        return view('livewire.admin-settings', [
+            'availableYears' => $this->getAvailableYearsWithCurrent(),
+            'currentTotal' => $this->getQualifyingTotal($this->selectedYear),
+            'priorYear' => $prior,
+            'priorTotal' => (int) ($historical[$prior] ?? $this->getQualifyingTotal($prior)),
+            'priorIsHistorical' => isset($historical[$prior]),
+        ]);
+    }
+
+    private function loadGoal(): void
+    {
+        $goal = Setting::get("community_goal_{$this->selectedYear}");
+        $this->goal = $goal !== null ? (int) $goal : null;
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function getAvailableYearsWithCurrent(): array
+    {
+        // Floor at the launch year, exactly as CommunityStats::getAvailableYears()
+        // does, so the admin year picker never offers a pre-launch year the public
+        // stats page would reject (and for which getQualifyingTotal() is a silent 0).
+        $launchYear = (int) config('app.start_year', 2026);
+
+        return collect($this->getAvailableYears())
+            ->push(now()->year)
+            ->filter(fn ($year) => $year >= $launchYear)
+            ->unique()
+            ->sortDesc()
+            ->values()
+            ->toArray();
+    }
+
+    /**
+     * Community-wide qualifying total for the year (sailing days plus up to
+     * 5 non-sailing days per sailor) — same math as the leaderboard.
+     */
+    private function getQualifyingTotal(int $year): int
+    {
+        $row = DB::query()
+            ->fromSub(
+                DB::table('flashes')
+                    ->select([
+                        'user_id',
+                        DB::raw("SUM(CASE WHEN activity_type = 'sailing' THEN 1 ELSE 0 END) as sailing_count"),
+                        DB::raw("SUM(CASE WHEN activity_type IN ('maintenance', 'race_committee') THEN 1 ELSE 0 END) as non_sailing_count"),
+                    ])
+                    ->whereRaw("strftime('%Y', date) = ?", [(string) $year])
+                    ->groupBy('user_id'),
+                'user_flashes'
+            )
+            ->selectRaw('COALESCE(SUM('.CommunityStats::QUALIFYING_SQL.'), 0) as total')
+            ->first();
+
+        return (int) ($row->total ?? 0);
+    }
+}

--- a/app/Livewire/CommunityStats.php
+++ b/app/Livewire/CommunityStats.php
@@ -1,0 +1,796 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\District;
+use App\Models\Fleet;
+use App\Models\Setting;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+/**
+ * Public community statistics page (/stats).
+ *
+ * All aggregate data for a year is computed in statsForYear() and cached for
+ * 15 minutes. Chart data is passed to D3 (resources/js/stats-charts.js) via a
+ * JSON script tag on initial load, and via the 'community-stats-updated'
+ * browser event when the year changes.
+ */
+class CommunityStats extends Component
+{
+    private const CACHE_MINUTES = 15;
+
+    // Bump when the cached stats shape changes, so old payloads are ignored
+    // rather than 500-ing the view after a deploy.
+    private const CACHE_VERSION = 13;
+
+    #[Url]
+    public int $selectedYear;
+
+    public function mount(): void
+    {
+        $available = $this->getAvailableYears();
+
+        if (! isset($this->selectedYear) || ! in_array($this->selectedYear, $available)) {
+            $this->selectedYear = now()->year;
+        }
+    }
+
+    public function updatedSelectedYear(): void
+    {
+        if (! in_array($this->selectedYear, $this->getAvailableYears())) {
+            $this->selectedYear = now()->year;
+        }
+
+        $stats = $this->statsForYear($this->selectedYear);
+
+        $this->dispatch('community-stats-updated', payload: $this->chartPayload($stats));
+    }
+
+    public function render()
+    {
+        $stats = $this->statsForYear($this->selectedYear);
+        $goal = $this->getCommunityGoal($this->selectedYear);
+        $priorTotal = $stats['priorTotal'];
+
+        return view('livewire.community-stats', [
+            'stats' => $stats,
+            'goal' => $goal,
+            'goalPercent' => $goal ? (int) round(min(100, $stats['counters']['totalQualifying'] / $goal * 100)) : null,
+            'priorTotal' => $priorTotal,
+            // Prior-year total as a fraction of the goal, for the benchmark line
+            'priorPercent' => ($goal && $priorTotal > 0) ? min(100, $priorTotal / $goal * 100) : null,
+            'goalIsDefault' => $this->goalIsDefault($this->selectedYear),
+            'availableYears' => $this->getAvailableYears(),
+            'chartJson' => json_encode($this->chartPayload($stats), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT),
+        ]);
+    }
+
+    public static function clearCache(int $year): void
+    {
+        Cache::forget(self::cacheKey($year));
+    }
+
+    private static function cacheKey(int $year): string
+    {
+        return 'community-stats-v'.self::CACHE_VERSION."-{$year}";
+    }
+
+    /**
+     * Years available in the selector: every year with flash activity, plus
+     * the current year (so the page works before the first flash of a year).
+     *
+     * @return array<int>
+     */
+    private function getAvailableYears(): array
+    {
+        // The app launched in start_year (2026); pre-launch years have no
+        // in-app per-day data and are never selectable.
+        $launchYear = (int) config('app.start_year', 2026);
+
+        return DB::table('flashes')
+            ->selectRaw('DISTINCT strftime("%Y", date) as year')
+            ->pluck('year')
+            ->map(fn ($year) => (int) $year)
+            ->push(now()->year)
+            ->filter(fn ($year) => $year >= $launchYear)
+            ->unique()
+            ->sortDesc()
+            ->values()
+            ->toArray();
+    }
+
+    private function getCommunityGoal(int $year): ?int
+    {
+        $goal = Setting::get("community_goal_{$year}");
+
+        if ($goal !== null) {
+            return (int) $goal;
+        }
+
+        // Fall back to the configured default so a fresh deploy shows a target.
+        $default = config('community.default_goal');
+
+        return $default !== null ? (int) $default : null;
+    }
+
+    private function goalIsDefault(int $year): bool
+    {
+        return Setting::get("community_goal_{$year}") === null;
+    }
+
+    /**
+     * The subset of statsForYear() that the D3 charts consume.
+     */
+    private function chartPayload(array $stats): array
+    {
+        return [
+            'year' => $stats['year'],
+            'monthsToShow' => $stats['monthsToShow'],
+            'heatmap' => $stats['heatmap'],
+            'sailorGrowth' => $stats['sailorGrowth'],
+            'flashFilter' => $stats['flashFilter'],
+            'ages' => $stats['ages'],
+            'funnel' => $stats['funnel'],
+        ];
+    }
+
+    private function statsForYear(int $year): array
+    {
+        return Cache::remember(
+            self::cacheKey($year),
+            now()->addMinutes(self::CACHE_MINUTES),
+            fn () => $this->buildStats($year)
+        );
+    }
+
+    private function buildStats(int $year): array
+    {
+        return [
+            'year' => $year,
+            'monthsToShow' => $year === now()->year ? now()->month : 12,
+            'counters' => $this->getKeyCounters($year),
+            'priorTotal' => $this->getPriorYearTotal($year),
+            'heatmap' => $this->getActivityHeatmap($year),
+            'sailorGrowth' => $this->getSailorGrowthData($year),
+            'flashFilter' => $this->getFlashFilterData($year),
+            'ages' => $this->getAgeDistribution($year),
+            'funnel' => $this->getAwardFunnel($year),
+            'busiestDay' => $this->getBusiestDay($year),
+            'funFacts' => $this->getFunFacts($year),
+        ];
+    }
+
+    // Finest-grained flash category (stack order): sailing event types, then
+    // the two non-sailing activity types.
+    private const FLASH_CATEGORIES = ['regatta', 'club_race', 'practice', 'leisure', 'maintenance', 'race_committee'];
+
+    private function ageGroupKey(?int $age): string
+    {
+        // $age is calendar-year age (statsYear - birthYear) = the age the sailor
+        // reaches by Dec 31 of the stats year. This is a deliberate convention, not
+        // an approximation: it matches how one-design age divisions ("U32") are
+        // defined and stays stable regardless of when the page is viewed, unlike an
+        // exact age-as-of-today that would shift a sailor across a division mid-season.
+        //
+        // Babies and young children are legitimately brought aboard, so there is
+        // no lower age floor. Only a missing DOB or an implausible age (a future
+        // or absurd birth year from bad data) reads as Unknown, rather than being
+        // forced into a real division.
+        if ($age === null || $age < 0 || $age > 100) {
+            return 'unknown';
+        }
+        if ($age <= 20) {
+            return 'youth';
+        }
+        if ($age <= 32) {
+            return 'u32';
+        }
+        if ($age <= 54) {
+            return 'mid';
+        }
+
+        return 'masters';
+    }
+
+    // Displayed group orders for the demographic charts. Members whose gender is
+    // undisclosed, or whose age is unknown (missing/typo'd DOB), are redistributed
+    // into these groups in proportion to the disclosed population (see
+    // redistributeUnknown()), so no Unknown/Undisclosed series can single them out.
+    private const GENDER_GROUPS = ['male', 'female', 'non_binary'];
+
+    private const AGE_GROUPS = ['youth', 'u32', 'mid', 'masters'];
+
+    // Raw dimension keys for a member (the sentinel marks undisclosed/unknown).
+    private function rawGenderKey(?string $gender): string
+    {
+        return in_array($gender, self::GENDER_GROUPS, true) ? $gender : 'prefer_not_to_say';
+    }
+
+    private function ageKeyFromDob(?string $dob, int $year): string
+    {
+        return $this->ageGroupKey($dob ? $year - (int) substr($dob, 0, 4) : null);
+    }
+
+    /**
+     * Proportionally impute a dimension's "unknown" members into the displayed
+     * groups, so the charts carry no Unknown/Undisclosed series and members who
+     * opted out (or have bad data) can't be re-identified from a lone small cell.
+     * Deterministic largest-remainder (Hamilton) allocation keyed on user id:
+     * reproducible across renders, integer counts, no fabricated fractions.
+     *
+     * @param  array<int, string>  $raw  userId => raw group key
+     * @param  string  $unknownKey  the sentinel to redistribute
+     * @param  list<string>  $displayGroups  displayed groups, in order
+     * @return array<int, string> userId => resolved group key
+     */
+    private function redistributeUnknown(array $raw, string $unknownKey, array $displayGroups): array
+    {
+        $known = array_fill_keys($displayGroups, 0);
+        $unknownIds = [];
+        foreach ($raw as $uid => $group) {
+            if (isset($known[$group])) {
+                $known[$group]++;
+            } else {
+                $unknownIds[] = $uid; // the unknown sentinel (or any stray value)
+            }
+        }
+
+        $totalKnown = array_sum($known);
+        // Nothing disclosed to base proportions on (real data never hits this),
+        // or nothing to redistribute — leave the input untouched.
+        if ($totalKnown === 0 || $unknownIds === []) {
+            return $raw;
+        }
+
+        sort($unknownIds); // stable, deterministic assignment order
+        $n = count($unknownIds);
+
+        // Largest-remainder quotas proportional to the disclosed distribution.
+        $quota = $remainder = [];
+        $seated = 0;
+        foreach ($displayGroups as $group) {
+            $exact = $known[$group] / $totalKnown * $n;
+            $quota[$group] = (int) floor($exact);
+            $remainder[$group] = $exact - $quota[$group];
+            $seated += $quota[$group];
+        }
+        // Hand out leftover seats to the largest remainders (ties → display order).
+        $byRemainder = $displayGroups;
+        usort($byRemainder, fn ($a, $b) => ($remainder[$b] <=> $remainder[$a])
+            ?: (array_search($a, $displayGroups) <=> array_search($b, $displayGroups)));
+        foreach (array_slice($byRemainder, 0, $n - $seated) as $group) {
+            $quota[$group]++;
+        }
+
+        $resolved = $raw;
+        $i = 0;
+        foreach ($displayGroups as $group) {
+            for ($k = 0; $k < $quota[$group]; $k++) {
+                $resolved[$unknownIds[$i++]] = $group;
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Per-(date, category, gender, age-group) flash counts, plus the dimension
+     * values present, for the client-side-filterable cumulative chart. The
+     * frontend re-aggregates as toggles change, so counts stay at daily
+     * increments here (not cumulative). Undisclosed gender / unknown age are
+     * redistributed per member so those series never appear.
+     */
+    private function getFlashFilterData(int $year): array
+    {
+        $flashes = DB::table('flashes as f')
+            ->join('users as u', 'u.id', '=', 'f.user_id')
+            ->selectRaw("f.user_id as user_id, DATE(f.date) as day, CASE WHEN f.activity_type = 'sailing' THEN f.event_type ELSE f.activity_type END as category, u.gender as gender, u.date_of_birth as dob")
+            ->whereRaw("strftime('%Y', f.date) = ?", [(string) $year])
+            ->get();
+
+        // Resolve each member's gender/age once, redistributing undisclosed/unknown.
+        $rawGender = $rawAge = [];
+        foreach ($flashes as $flash) {
+            $rawGender[$flash->user_id] = $this->rawGenderKey($flash->gender);
+            $rawAge[$flash->user_id] = $this->ageKeyFromDob($flash->dob, $year);
+        }
+        $gender = $this->redistributeUnknown($rawGender, 'prefer_not_to_say', self::GENDER_GROUPS);
+        $age = $this->redistributeUnknown($rawAge, 'unknown', self::AGE_GROUPS);
+
+        $agg = [];
+        foreach ($flashes as $flash) {
+            if (! in_array($flash->category, self::FLASH_CATEGORIES, true)) {
+                continue;
+            }
+            $key = "{$flash->day}\x1f{$flash->category}\x1f{$gender[$flash->user_id]}\x1f{$age[$flash->user_id]}";
+            $agg[$key] = ($agg[$key] ?? 0) + 1;
+        }
+
+        $rows = [];
+        $seenGenders = $seenAges = $seenCats = [];
+        foreach ($agg as $key => $count) {
+            [$day, $category, $gender, $ageGroup] = explode("\x1f", $key);
+            $rows[] = ['date' => $day, 'category' => $category, 'gender' => $gender, 'ageGroup' => $ageGroup, 'count' => $count];
+            $seenGenders[$gender] = $seenAges[$ageGroup] = $seenCats[$category] = true;
+        }
+
+        $genderLabels = ['male' => 'Male', 'female' => 'Female', 'non_binary' => 'Non-binary', 'prefer_not_to_say' => 'Undisclosed'];
+        $ageLabels = ['youth' => 'Youth', 'u32' => 'U32', 'mid' => '33–54', 'masters' => 'Masters', 'unknown' => 'Unknown'];
+        $catLabels = ['regatta' => 'Regatta', 'club_race' => 'Club Race', 'practice' => 'Practice', 'leisure' => 'Day Sailing', 'maintenance' => 'Maintenance', 'race_committee' => 'Race Committee'];
+
+        $present = fn (array $order, array $labels, array $seen) => array_values(array_map(
+            fn ($k) => ['key' => $k, 'label' => $labels[$k]],
+            array_filter($order, fn ($k) => isset($seen[$k]))
+        ));
+
+        return [
+            'rows' => $rows,
+            'genders' => $present(array_keys($genderLabels), $genderLabels, $seenGenders),
+            'ageGroups' => $present(array_keys($ageLabels), $ageLabels, $seenAges),
+            'categories' => $present(self::FLASH_CATEGORIES, $catLabels, $seenCats),
+        ];
+    }
+
+    /**
+     * Sailor growth at date resolution, broken down by gender and age group so
+     * the frontend can stack by either. Accounts created before the year collapse
+     * to a year-start baseline; created_at is a full timestamp so points track
+     * actual signup dates. Also returns cumulative totals for the table twin.
+     */
+    private function getSailorGrowthData(int $year): array
+    {
+        $users = DB::table('users')
+            ->selectRaw("id as user_id, DATE(created_at) as day, CAST(strftime('%Y', created_at) AS INTEGER) as created_year, gender, date_of_birth as dob")
+            ->whereRaw('CAST(strftime(\'%Y\', created_at) AS INTEGER) <= ?', [$year])
+            ->get();
+
+        // Resolve each member's gender/age once, redistributing undisclosed/unknown.
+        $rawGender = $rawAge = [];
+        foreach ($users as $user) {
+            $rawGender[$user->user_id] = $this->rawGenderKey($user->gender);
+            $rawAge[$user->user_id] = $this->ageKeyFromDob($user->dob, $year);
+        }
+        $gender = $this->redistributeUnknown($rawGender, 'prefer_not_to_say', self::GENDER_GROUPS);
+        $age = $this->redistributeUnknown($rawAge, 'unknown', self::AGE_GROUPS);
+
+        $agg = [];
+        $perDate = [];
+        foreach ($users as $user) {
+            $date = ((int) $user->created_year < $year) ? "{$year}-01-01" : $user->day;
+            $key = "{$date}\x1f{$gender[$user->user_id]}\x1f{$age[$user->user_id]}";
+            $agg[$key] = ($agg[$key] ?? 0) + 1;
+            $perDate[$date] = ($perDate[$date] ?? 0) + 1;
+        }
+
+        $rows = [];
+        $seenGenders = $seenAges = [];
+        foreach ($agg as $key => $count) {
+            [$date, $gender, $ageGroup] = explode("\x1f", $key);
+            $rows[] = ['date' => $date, 'gender' => $gender, 'ageGroup' => $ageGroup, 'count' => $count];
+            $seenGenders[$gender] = $seenAges[$ageGroup] = true;
+        }
+
+        ksort($perDate);
+        $running = 0;
+        $totals = [];
+        foreach ($perDate as $date => $count) {
+            $running += $count;
+            $totals[] = ['date' => $date, 'total' => $running];
+        }
+
+        $genderLabels = ['male' => 'Male', 'female' => 'Female', 'non_binary' => 'Non-binary', 'prefer_not_to_say' => 'Undisclosed'];
+        $ageLabels = ['youth' => 'Youth', 'u32' => 'U32', 'mid' => '33–54', 'masters' => 'Masters', 'unknown' => 'Unknown'];
+        $present = fn (array $order, array $labels, array $seen) => array_values(array_map(
+            fn ($k) => ['key' => $k, 'label' => $labels[$k]],
+            array_filter($order, fn ($k) => isset($seen[$k]))
+        ));
+
+        return [
+            'rows' => $rows,
+            'genders' => $present(array_keys($genderLabels), $genderLabels, $seenGenders),
+            'ageGroups' => $present(array_keys($ageLabels), $ageLabels, $seenAges),
+            'totals' => $totals,
+        ];
+    }
+
+    /**
+     * Per-user flash aggregation for a year (same pattern as the leaderboard):
+     * sailing_count and non_sailing_count per user, for qualifying-total math.
+     */
+    private function userFlashesSubquery(int $year)
+    {
+        return DB::table('flashes')
+            ->select([
+                'user_id',
+                DB::raw("SUM(CASE WHEN activity_type = 'sailing' THEN 1 ELSE 0 END) as sailing_count"),
+                DB::raw("SUM(CASE WHEN activity_type IN ('maintenance', 'race_committee') THEN 1 ELSE 0 END) as non_sailing_count"),
+            ])
+            ->whereRaw("strftime('%Y', date) = ?", [(string) $year])
+            ->groupBy('user_id');
+    }
+
+    /**
+     * Most recent membership per user (carry-forward: latest year <= target),
+     * matching the leaderboard's membership resolution.
+     */
+    private function recentMembershipSubquery(int $year)
+    {
+        return DB::table('members as m1')
+            ->select('m1.*')
+            ->joinSub(
+                DB::table('members')
+                    ->select('user_id', DB::raw('MAX(year) as max_year'))
+                    ->where('year', '<=', $year)
+                    ->groupBy('user_id'),
+                'm2',
+                function ($join) {
+                    $join->on('m1.user_id', '=', 'm2.user_id')
+                        ->on('m1.year', '=', 'm2.max_year');
+                }
+            );
+    }
+
+    // Qualifying total per user: sailing days + at most 5 non-sailing days.
+    // Canonical expression for the "5 non-sailing days per year" cap — shared
+    // with AdminSettings so the admin goal page can never desync from /stats.
+    // Expects `sailing_count`/`non_sailing_count` columns in the enclosing query.
+    public const QUALIFYING_SQL = 'sailing_count + CASE WHEN non_sailing_count > 5 THEN 5 ELSE non_sailing_count END';
+
+    private function getKeyCounters(int $year): array
+    {
+        $totals = DB::query()
+            ->fromSub($this->userFlashesSubquery($year), 'user_flashes')
+            ->selectRaw('COUNT(*) as sailors')
+            ->selectRaw('COALESCE(SUM('.self::QUALIFYING_SQL.'), 0) as total_qualifying')
+            ->selectRaw('COALESCE(SUM(CASE WHEN '.self::QUALIFYING_SQL.' >= 10 THEN 1 ELSE 0 END), 0) as achievers')
+            ->first();
+
+        // The sentinel "None" fleet / "Unaffiliated/None" district are real rows
+        // (affiliations are never null) but don't count as active groups.
+        $groups = DB::query()
+            ->fromSub($this->userFlashesSubquery($year), 'user_flashes')
+            ->joinSub($this->recentMembershipSubquery($year), 'recent_members', 'user_flashes.user_id', '=', 'recent_members.user_id')
+            ->selectRaw('COUNT(DISTINCT CASE WHEN recent_members.fleet_id != ? THEN recent_members.fleet_id END) as fleets', [Fleet::noneId()])
+            ->selectRaw('COUNT(DISTINCT CASE WHEN recent_members.district_id != ? THEN recent_members.district_id END) as districts', [District::noneId()])
+            ->first();
+
+        return [
+            'totalQualifying' => (int) $totals->total_qualifying,
+            'activeSailors' => (int) $totals->sailors,
+            'activeFleets' => (int) ($groups->fleets ?? 0),
+            'activeDistricts' => (int) ($groups->districts ?? 0),
+            'awardAchievers' => (int) $totals->achievers,
+        ];
+    }
+
+    /**
+     * The prior year's community total, for the benchmark line. Pre-launch
+     * years (no in-app data) fall back to the hardcoded historical aggregate
+     * from the old manual process (config/community.php).
+     */
+    private function getPriorYearTotal(int $year): int
+    {
+        $prior = $year - 1;
+        $historical = config('community.historical_totals', []);
+
+        return (int) ($historical[$prior] ?? $this->getQualifyingTotal($prior));
+    }
+
+    /**
+     * Community-wide qualifying total for a year (sailing days plus up to 5
+     * non-sailing days per sailor). Used for the prior-year benchmark line.
+     */
+    private function getQualifyingTotal(int $year): int
+    {
+        $row = DB::query()
+            ->fromSub($this->userFlashesSubquery($year), 'user_flashes')
+            ->selectRaw('COALESCE(SUM('.self::QUALIFYING_SQL.'), 0) as total')
+            ->first();
+
+        return (int) ($row->total ?? 0);
+    }
+
+    /**
+     * Flash count per date, for the contribution-style heatmap.
+     *
+     * @return array<string, int> 'Y-m-d' => count
+     */
+    private function getActivityHeatmap(int $year): array
+    {
+        return DB::table('flashes')
+            ->selectRaw('DATE(date) as day, COUNT(*) as count')
+            ->whereRaw("strftime('%Y', date) = ?", [(string) $year])
+            ->groupBy('day')
+            ->orderBy('day')
+            ->pluck('count', 'day')
+            ->map(fn ($count) => (int) $count)
+            ->toArray();
+    }
+
+    // Gender display labels + canonical order (also the stack order, bottom→top).
+    // "Prefer not to say" / unset carry no series of their own — those members
+    // are redistributed into the displayed genders (see redistributeUnknown()),
+    // so a tiny undisclosed cell can never single someone out on a public page.
+    private const GENDER_LABELS = [
+        'female' => 'Female',
+        'male' => 'Male',
+        'non_binary' => 'Non-binary',
+    ];
+
+    /**
+     * Age distribution of sailors active in the year, bucketed by Lightning
+     * Class age division and split by gender. Youth and U32 are the class's
+     * growth segments; Masters is 55+. Undisclosed gender and unknown age
+     * (implausible/typo'd or missing birth dates) are redistributed into the
+     * displayed groups, so there is no Unknown/Undisclosed cell. Only genders
+     * present are returned.
+     */
+    private function getAgeDistribution(int $year): array
+    {
+        $rows = DB::query()
+            ->fromSub($this->userFlashesSubquery($year), 'user_flashes')
+            ->join('users', 'users.id', '=', 'user_flashes.user_id')
+            ->selectRaw('users.id as user_id, users.date_of_birth as dob, users.gender as gender')
+            ->get();
+
+        // Resolve each active sailor's gender/age once, redistributing undisclosed
+        // gender and unknown age into the displayed groups.
+        $rawGender = $rawAge = [];
+        foreach ($rows as $r) {
+            $rawGender[$r->user_id] = $this->rawGenderKey($r->gender);
+            $rawAge[$r->user_id] = $this->ageKeyFromDob($r->dob, $year);
+        }
+        $genderMap = $this->redistributeUnknown($rawGender, 'prefer_not_to_say', self::GENDER_GROUPS);
+        $ageMap = $this->redistributeUnknown($rawAge, 'unknown', self::AGE_GROUPS);
+        $sailors = $rows->map(fn ($r) => (object) [
+            'ageGroup' => $ageMap[$r->user_id],
+            'gender' => $genderMap[$r->user_id],
+        ]);
+
+        // Ordered young → old. "Open" was dropped — in sailing "open" means the
+        // all-comers division, not an age band. No Unknown bucket: unknown ages
+        // are redistributed into these divisions.
+        $divisions = [
+            ['label' => 'Youth', 'range' => '20 & under', 'key' => 'youth'],
+            ['label' => 'U32', 'range' => '21–32', 'key' => 'u32'],
+            ['label' => '33–54', 'range' => '33–54', 'key' => 'mid'],
+            ['label' => 'Masters', 'range' => '55 & over', 'key' => 'masters'],
+        ];
+
+        // Genders actually present, in canonical order.
+        $present = array_values(array_filter(
+            array_keys(self::GENDER_LABELS),
+            fn ($g) => $sailors->contains('gender', $g)
+        ));
+
+        // Degenerate all-undisclosed year: redistribution had no disclosed group
+        // to impute into, so surface the undisclosed sailors rather than an empty
+        // chart. Only reachable if every active sailor that year is undisclosed.
+        if ($present === [] && $sailors->isNotEmpty()) {
+            $present = ['prefer_not_to_say'];
+        }
+
+        $genderLabel = fn (string $g): string => self::GENDER_LABELS[$g] ?? 'Undisclosed';
+
+        $counts = [];
+        foreach ($divisions as $d) {
+            $inDivision = $sailors->where('ageGroup', $d['key']);
+            $counts[$d['label']] = [];
+            foreach ($present as $g) {
+                $counts[$d['label']][$g] = $inDivision->where('gender', $g)->count();
+            }
+        }
+
+        return [
+            'labels' => array_column($divisions, 'label'),
+            'ranges' => array_column($divisions, 'range'),
+            'genders' => array_map(fn ($g) => ['key' => $g, 'label' => $genderLabel($g)], $present),
+            'counts' => $counts,
+        ];
+    }
+
+    /**
+     * Award-progress funnel: cumulative "reached at least this stage" counts,
+     * from registered accounts down through activation and each award tier, so
+     * the drop-off at each step is visible.
+     *
+     * @return array<array{label: string, count: int}>
+     */
+    private function getAwardFunnel(int $year): array
+    {
+        $registered = DB::table('users')
+            ->whereRaw("strftime('%Y', created_at) <= ?", [(string) $year])
+            ->count();
+
+        $row = DB::query()
+            ->fromSub($this->userFlashesSubquery($year), 'user_flashes')
+            ->selectRaw('COUNT(*) as active')
+            ->selectRaw('SUM(CASE WHEN '.self::QUALIFYING_SQL.' >= 10 THEN 1 ELSE 0 END) as reached10')
+            ->selectRaw('SUM(CASE WHEN '.self::QUALIFYING_SQL.' >= 25 THEN 1 ELSE 0 END) as reached25')
+            ->selectRaw('SUM(CASE WHEN '.self::QUALIFYING_SQL.' >= 50 THEN 1 ELSE 0 END) as reached50')
+            ->first();
+
+        return [
+            ['label' => 'Registered', 'count' => $registered],
+            ['label' => 'Logged a day', 'count' => (int) ($row->active ?? 0)],
+            ['label' => '10-day award', 'count' => (int) ($row->reached10 ?? 0)],
+            ['label' => '25-day award', 'count' => (int) ($row->reached25 ?? 0)],
+            ['label' => '50-day award', 'count' => (int) ($row->reached50 ?? 0)],
+        ];
+    }
+
+    /**
+     * Dynamically generated highlight cards. Facts without enough data are
+     * skipped rather than rendered empty.
+     *
+     * @return array<array{title: string, value: string, detail: string}>
+     */
+    /**
+     * Busiest day on the water: the date with the most distinct sailing sailors.
+     * Shown as a caption on the activity-heatmap card. Null below 2 sailors.
+     *
+     * @return array{date: string, sailors: int}|null
+     */
+    private function getBusiestDay(int $year): ?array
+    {
+        $busiest = DB::table('flashes')
+            ->selectRaw('DATE(date) as day, COUNT(DISTINCT user_id) as sailors')
+            ->where('activity_type', 'sailing')
+            ->whereRaw("strftime('%Y', date) = ?", [(string) $year])
+            ->groupBy('day')
+            ->orderByDesc('sailors')
+            ->orderBy('day')
+            ->first();
+
+        if (! $busiest || $busiest->sailors < 2) {
+            return null;
+        }
+
+        return [
+            'date' => Carbon::parse($busiest->day)->format('F j'),
+            'sailors' => (int) $busiest->sailors,
+        ];
+    }
+
+    private function getFunFacts(int $year): array
+    {
+        $facts = [];
+
+        // Season opener — the first sailing day of the year, and who logged it.
+        $opener = DB::table('flashes as f')
+            ->join('users as u', 'u.id', '=', 'f.user_id')
+            ->selectRaw('u.first_name, u.last_name, DATE(f.date) as day')
+            ->where('f.activity_type', 'sailing')
+            ->whereRaw("strftime('%Y', f.date) = ?", [(string) $year])
+            ->orderBy('f.date')
+            ->orderBy('f.created_at')
+            ->first();
+
+        if ($opener) {
+            $facts[] = [
+                'title' => 'Season opener',
+                'value' => Carbon::parse($opener->day)->format('F j'),
+                'detail' => "{$opener->first_name} {$opener->last_name} logged the season's first sailing day",
+            ];
+        }
+
+        // Longest sailing streak — the most consecutive calendar days a sailor
+        // logged a sailing flash; a tie credits everyone. Streak logic is clearer
+        // in PHP than SQL.
+        $streak = $this->getLongestSailingStreak($year);
+        if ($streak && $streak['days'] >= 3) {
+            $names = $streak['names'];
+            $days = $streak['days'];
+            if (count($names) === 1) {
+                $detail = "{$names[0]} sailed {$days} days in a row";
+            } elseif (count($names) === 2) {
+                $detail = "{$names[0]} and {$names[1]} each sailed {$days} days in a row";
+            } else {
+                $detail = "{$names[0]} and ".(count($names) - 1)." others each sailed {$days} days in a row";
+            }
+            $facts[] = [
+                'title' => 'Longest sailing streak',
+                'value' => "{$days} days",
+                'detail' => $detail,
+            ];
+        }
+
+        // Most flashes logged at once — the largest single bulk entry, i.e. the
+        // most flashes one sailor created in a single save (multi-date logging
+        // shares one created_at timestamp).
+        $batch = DB::table('flashes as f')
+            ->join('users as u', 'u.id', '=', 'f.user_id')
+            ->selectRaw('u.first_name, u.last_name, COUNT(*) as n')
+            ->whereRaw("strftime('%Y', f.date) = ?", [(string) $year])
+            ->groupBy('f.user_id', 'f.created_at')
+            ->orderByDesc('n')
+            ->orderBy('f.created_at')
+            ->first();
+
+        if ($batch && $batch->n >= 2) {
+            $facts[] = [
+                'title' => 'Most flashes logged at once',
+                'value' => "{$batch->n} flashes",
+                'detail' => "Logged in a single entry by {$batch->first_name} {$batch->last_name}",
+            ];
+        }
+
+        // The 50+ club
+        $fiftyClub = DB::query()
+            ->fromSub($this->userFlashesSubquery($year), 'user_flashes')
+            ->selectRaw('SUM(CASE WHEN '.self::QUALIFYING_SQL.' >= 50 THEN 1 ELSE 0 END) as count')
+            ->first();
+
+        if ($fiftyClub && $fiftyClub->count > 0) {
+            $facts[] = [
+                'title' => 'The 50+ club',
+                'value' => "{$fiftyClub->count} ".($fiftyClub->count == 1 ? 'sailor' : 'sailors'),
+                'detail' => 'Earned all three awards this year',
+            ];
+        }
+
+        return $facts;
+    }
+
+    /**
+     * The longest run of consecutive calendar days a sailor logged a sailing
+     * flash, and the names of everyone tied at that length (so a tie credits all
+     * of them, not an arbitrary pick). Consecutive-day detection is a simple
+     * linear scan in PHP (awkward in portable SQL).
+     *
+     * @return array{days: int, names: list<string>}|null
+     */
+    private function getLongestSailingStreak(int $year): ?array
+    {
+        $rows = DB::table('flashes as f')
+            ->join('users as u', 'u.id', '=', 'f.user_id')
+            ->selectRaw('f.user_id, u.first_name, u.last_name, DATE(f.date) as day')
+            ->where('f.activity_type', 'sailing')
+            ->whereRaw("strftime('%Y', f.date) = ?", [(string) $year])
+            ->groupBy('f.user_id', 'day')
+            ->orderBy('f.user_id')
+            ->orderBy('day')
+            ->get();
+
+        // Longest consecutive-day run per sailor.
+        $perUser = [];
+        $currentUser = null;
+        $currentLen = 0;
+        $prevTs = null;
+
+        foreach ($rows as $row) {
+            $ts = strtotime($row->day);
+            if ($row->user_id !== $currentUser) {
+                $currentUser = $row->user_id;
+                $currentLen = 1;
+            } elseif ($ts - $prevTs === 86400) {
+                $currentLen++;
+            } else {
+                $currentLen = 1;
+            }
+            $prevTs = $ts;
+
+            $name = trim("{$row->first_name} {$row->last_name}");
+            if (! isset($perUser[$row->user_id]) || $currentLen > $perUser[$row->user_id]['len']) {
+                $perUser[$row->user_id] = ['len' => $currentLen, 'name' => $name];
+            }
+        }
+
+        if ($perUser === []) {
+            return null;
+        }
+
+        $max = max(array_column($perUser, 'len'));
+        $names = array_values(array_map(
+            fn ($u) => $u['name'],
+            array_filter($perUser, fn ($u) => $u['len'] === $max)
+        ));
+        usort($names, 'strcasecmp');
+
+        return ['days' => $max, 'names' => $names];
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Key-value application settings (e.g. the annual community sailing goal,
+ * stored under "community_goal_{year}").
+ */
+class Setting extends Model
+{
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    /**
+     * Get a setting value by key, or the default if not set.
+     */
+    public static function get(string $key, ?string $default = null): ?string
+    {
+        return static::where('key', $key)->value('value') ?? $default;
+    }
+
+    /**
+     * Set (create or update) a setting value. A null value clears the setting.
+     */
+    public static function set(string $key, ?string $value): void
+    {
+        static::updateOrCreate(['key' => $key], ['value' => $value]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -69,7 +69,18 @@ class User extends Authenticatable
             'password' => 'hashed',
             'date_of_birth' => 'date',
             'email_verification_expires_at' => 'datetime',
+            'is_admin' => 'boolean',
+            'is_super_admin' => 'boolean',
         ];
+    }
+
+    /**
+     * Site-operator tier (site settings and operational views), above the
+     * award-admin `is_admin`. Not guarded/fillable — set deliberately.
+     */
+    public function isSuperAdmin(): bool
+    {
+        return (bool) $this->is_super_admin;
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ use App\Http\Middleware\AdminMiddleware;
 use App\Http\Middleware\BasicAuthMiddleware;
 use App\Http\Middleware\ContentSecurityPolicy;
 use App\Http\Middleware\PreventIndexingNonProduction;
+use App\Http\Middleware\SuperAdminMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -37,6 +38,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->append(BasicAuthMiddleware::class);
         $middleware->alias([
             'admin' => AdminMiddleware::class,
+            'super_admin' => SuperAdminMiddleware::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/config/community.php
+++ b/config/community.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pre-launch historical totals
+    |--------------------------------------------------------------------------
+    |
+    | The app launched in 2026 (see app.start_year), so it has no per-day data
+    | for prior seasons. These community qualifying-day totals come from the old
+    | manual process and are used for the prior-year benchmark on the /stats
+    | hero and to inform the annual goal. They are NOT selectable years.
+    |
+    | 2025: 1550 logged sailor-days across 127 sailors (season 2025-02-13 to
+    | 2025-11-09). Source: 2025 season report (Report 12-10-25.xlsx) — one row per
+    | logged activity, crediting the sailor who sailed (not the submitting account).
+    | Every row is counted: last year's collection was messy but the rows are not
+    | true same-day duplicates, so they are NOT deduplicated. No activity-type split
+    | in the old data, so all count as sailing days.
+    | (The prior 696 came from collapsing rows by submission timestamp.)
+    |
+    */
+
+    'historical_totals' => [
+        2025 => 1550,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default community goal
+    |--------------------------------------------------------------------------
+    |
+    | Fallback annual qualifying-days goal shown on /stats when no year-specific
+    | goal has been set in the settings table, so a fresh deploy shows a target
+    | out of the box. A site admin can override per year at /admin/settings.
+    |
+    */
+
+    'default_goal' => 2500,
+
+];

--- a/database/migrations/2026_07_18_211000_create_settings_table.php
+++ b/database/migrations/2026_07_18_211000_create_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/migrations/2026_07_21_120000_add_is_super_admin_to_users.php
+++ b/database/migrations/2026_07_21_120000_add_is_super_admin_to_users.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Site-operator tier, above the award-admin `is_admin`. Gates site
+            // configuration (community goal now; operational views like issue #48
+            // later). Independent of is_admin — a user may hold either or both.
+            $table->boolean('is_super_admin')->default(false)->after('is_admin');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_super_admin');
+        });
+    }
+};

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -94,7 +94,8 @@ Users can export their complete profile and activity history:
 
 ### 1.5 User Roles
 - **Regular Users**: Can track their own activities and view their progress
-- **Award Administrators**: Responsible for viewing award eligibility and mailing physical awards to participants
+- **Award Administrators** (`is_admin`): View award eligibility and mail physical awards; access the award-fulfillment and sailor-logs dashboards
+- **Site Administrators** (`is_super_admin`): Elevated site-operator tier above award admin; access site configuration (the community goal at `/admin/settings`, and future operational views). Independent of the award-admin flag — a user may hold either or both
 
 ---
 
@@ -259,7 +260,38 @@ Public leaderboards to encourage friendly competition and community engagement.
 
 ---
 
-## 5. Award Fulfillment
+## 5. Community Statistics
+
+A public page (`/stats`) that celebrates class-wide participation and motivates sailors toward the annual community goal. All figures are community-level aggregates — no individual sailor is identifiable beyond the opt-in fun facts.
+
+**Community Goal Progress:**
+- A "lightning fill-up" hero animates a Lightning silhouette filling toward the year's community sailing-days goal
+- The goal defaults to a configured value (so a fresh deploy shows a target out of the box) and can be overridden per year by a site administrator at `/admin/settings` (stored in the `settings` table)
+- A benchmark line marks the prior year's final total, so progress is framed against last season
+
+**Key Counters:**
+- Headline totals for the year (e.g. qualifying days logged, active sailors, registered sailors, awards earned)
+
+**Charts** (all server-rendered with self-hosted D3 — no CDN — and each paired with an accessible, hover-free data-table twin):
+1. **When the community sails**: a day-by-day activity heatmap for the year, with the busiest day called out in a caption
+2. **Flashes over the season**: a running total of every flash, filterable by activity type, gender, and age group, and switchable between count and share (%)
+3. **Community growth**: a running total of registered sailors, stacked by age division or gender, count or share
+4. **Sailor ages**: active sailors grouped by Lightning Class age division and gender
+5. **From sign-up to award**: an award funnel from registered → active → each award tier
+
+**Fun Facts:**
+- Rotating human-interest highlights derived from the year's data (e.g. season opener, longest sailing streak, most flashes logged at once, the 50+ club); all tied sailors are credited
+
+**Age Divisions & Privacy:**
+- Age uses **calendar-year age** (the age a sailor reaches by Dec 31 of the stats year), matching how one-design age divisions are defined: Youth (≤20), U32 (≤32), Mid (≤54), Masters (55+). Babies and young children are legitimate crew and count as Youth (no lower age floor)
+- Undisclosed gender and unknown age (missing or implausible birth dates) are **redistributed** proportionally into the displayed groups, so the charts carry no Unknown/Undisclosed series and members who opted out of stating gender cannot be singled out from a small per-day cell — every sailor is still counted in the totals
+
+**Performance & Freshness:**
+- The full aggregate bundle is cached per year for 15 minutes (database cache store); saving a new community goal clears that year's cache immediately
+
+---
+
+## 6. Award Fulfillment
 
 The award fulfillment system provides administrators with tools to manage the physical award mailing process:
 
@@ -294,7 +326,7 @@ All admin status changes are logged to a dedicated admin log channel with user i
 
 ---
 
-## 6. Sailor Activity Logs (Admin)
+## 7. Sailor Activity Logs (Admin)
 
 Shows all sailor log entries across the program with filtering and export capabilities.
 
@@ -315,7 +347,7 @@ Admin users only.
 
 ---
 
-## 7. System Requirements
+## 8. System Requirements
 
 ### 7.1 Platform
 - Web-based application accessible on desktop and mobile devices
@@ -355,7 +387,7 @@ Admin users only.
 
 ---
 
-## 8. Future Considerations
+## 9. Future Considerations
 
 ### Potential Enhancements (Out of Scope for Initial Release)
 - Email notifications to award administrators when users reach award thresholds
@@ -365,7 +397,7 @@ Admin users only.
 - **Branding**: U32 image + transparent images without the barcode
 ---
 
-## 9. Success Metrics
+## 10. Success Metrics
 
 ### Key Performance Indicators
 - Number of registered participants year-over-year
@@ -391,4 +423,4 @@ Admin users only.
 
 ## Document Control
 
-**Last Updated**: June 1, 2026
+**Last Updated**: July 21, 2026

--- a/docs/screenshots/stats.jpg
+++ b/docs/screenshots/stats.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:722015e9576909d9a947acf79c58f18a899fbc4704f4c8a7703223f2598d6ddb
+size 564295

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,10 @@
     "": {
       "name": "gotflashes",
       "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-shape": "^3.2.0",
         "flatpickr": "^4.6.13",
         "tom-select": "^2.4.3"
       },
@@ -1007,9 +1011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1027,9 +1028,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,9 +1045,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1067,9 +1062,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1420,9 +1412,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1440,9 +1429,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,6 +2549,118 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/daisyui": {
@@ -3715,6 +3813,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4267,9 +4374,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4291,9 +4395,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
+    "d3-array": "^3.2.4",
+    "d3-scale": "^4.0.2",
+    "d3-selection": "^3.0.0",
+    "d3-shape": "^3.2.0",
     "flatpickr": "^4.6.13",
     "tom-select": "^2.4.3"
   }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -559,3 +559,394 @@ span.flatpickr-weekday {
     color: var(--color-accent-content);
     border-color: var(--color-accent);
 }
+
+/* ============================================================
+   Community Stats page (/stats)
+   ============================================================ */
+
+/* Lightning fill-up hero — a "thermometer" in the Lightning Class bolt insignia.
+   The bolt shape comes from the class logo PNG used as an alpha mask; a gradient
+   layer rises inside it toward the community goal, with a benchmark line marking
+   the prior year's total. Geometry: the bolt box is inset 15% inside the circle,
+   so fill/benchmark heights map to that central 70% band. */
+.lightning-fill {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.lightning-fill-goal {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-base-content);
+    opacity: 0.6;
+}
+
+.lightning-fill-goal span {
+    font-weight: 400;
+}
+
+.lightning-fill-circle {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    background: oklch(100% 0 0deg);
+    border: 5px solid var(--color-primary);
+    overflow: hidden;
+}
+
+.lightning-fill-bolt {
+    position: absolute;
+    inset: 15%;
+
+    /* The Lightning Class bolt insignia, as an alpha mask over the fill layers */
+    mask: url('../../public/images/lightning_logo.png') center / contain no-repeat;
+}
+
+.lightning-fill-track {
+    position: absolute;
+    inset: 0;
+    background: var(--color-base-300);
+}
+
+.lightning-fill-rise {
+    position: absolute;
+    inset: 0;
+
+    /* The Lightning Class bolt is red; it fills in its own colour */
+    background: linear-gradient(to top, var(--color-accent), oklch(58% 0.19 29deg));
+    clip-path: inset(calc(100% - var(--lf-fill, 0%)) 0 0 0);
+    animation: lightning-fill-rise 1.5s ease-out;
+}
+
+@keyframes lightning-fill-rise {
+    from {
+        clip-path: inset(100% 0 0 0);
+    }
+}
+
+/* Prior-year benchmark. Two parts: a solid line across the bolt (masked to the
+   bolt so it spans exactly the red at that height and never overhangs), and a
+   dashed leader running right to the year chip. */
+.lightning-fill-prior-solid {
+    position: absolute;
+    inset: 15%;
+    pointer-events: none;
+    mask: url('../../public/images/lightning_logo.png') center / contain no-repeat;
+}
+
+.lightning-fill-prior-solid::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(var(--lf-prior, 0) * 100%);
+
+    /* Dark blue reads clearly over the red bolt fill */
+    border-top: 1.5px solid var(--color-primary);
+}
+
+.lightning-fill-prior-leader {
+    position: absolute;
+
+    /* Starts just past the bolt's right edge at the benchmark height, so the
+       dashes sit on the white only — the solid part carries it across the bolt. */
+    left: 61%;
+    right: 13%;
+    bottom: calc(15% + var(--lf-prior, 0) * 70%);
+    border-top: 1px dashed var(--color-secondary);
+    pointer-events: none;
+}
+
+.lightning-fill-prior-chip {
+    position: absolute;
+    right: 11%;
+    bottom: calc(15% + var(--lf-prior, 0) * 70%);
+    transform: translateY(50%);
+    font-size: 0.6rem;
+    font-weight: 700;
+    line-height: 1.2;
+    padding: 0 0.25rem;
+    border-radius: 3px;
+    color: var(--color-secondary);
+    background: oklch(100% 0 0deg / 88%);
+}
+
+/* Goal reached: gentle glow pulse after the fill animation lands */
+.lightning-fill-complete .lightning-fill-circle {
+    animation: lightning-glow-pulse 2.4s ease-in-out 1.6s infinite;
+}
+
+@keyframes lightning-glow-pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 4px oklch(55% 0.12 240deg / 45%);
+    }
+
+    50% {
+        box-shadow: 0 0 20px oklch(55% 0.12 240deg / 90%);
+    }
+}
+
+/* Respect reduced-motion: the fill and glow settle straight to their resting
+   state (the clip-path level is applied regardless — only the animation drops). */
+@media (prefers-reduced-motion: reduce) {
+    .lightning-fill-rise,
+    .lightning-fill-complete .lightning-fill-circle {
+        animation: none;
+    }
+}
+
+/* D3 chart containers */
+.stats-chart {
+    position: relative;
+    width: 100%;
+}
+
+.stats-chart svg {
+    display: block;
+    max-width: 100%;
+}
+
+/* Wide charts (heatmap) scroll inside their own container only when they
+   overflow; JS centres them and switches off the scrollbar when they fit. */
+.stats-chart .chart-scroll {
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+}
+
+.stats-chart .chart-scroll svg {
+    max-width: none;
+}
+
+/* Filterable cumulative-flashes chart: toggle chips grouped by dimension */
+.stats-chart .flash-filter-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.stats-chart .flash-filter-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.stats-chart .ff-group-label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    opacity: 0.55;
+    margin-right: 0.15rem;
+}
+
+/* Multi-select toggle pill — pressed/unpressed states so it reads as a control,
+   not a legend swatch. */
+.stats-chart .ff-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.72rem;
+    line-height: 1.4;
+    padding: 0.16rem 0.6rem;
+    border-radius: 9999px;
+    border: 1px solid var(--color-base-300);
+    background: var(--color-base-100);
+    color: var(--color-base-content);
+    cursor: pointer;
+    transition: background 0.12s ease, border-color 0.12s ease, opacity 0.12s ease;
+}
+
+.stats-chart .ff-chip:hover {
+    background: var(--color-base-200);
+    border-color: var(--color-base-content);
+}
+
+.stats-chart .ff-chip:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+}
+
+/* On = included: clean neutral pill — colour lives in the swatch, not a fill,
+   so an all-on row stays calm. The swatch + hover carry the affordance. */
+.stats-chart .ff-chip[data-on='1'] {
+    border-color: var(--color-base-300);
+    background: var(--color-base-100);
+}
+
+/* Off = excluded: faded + struck through, an unambiguous "removed" signal. */
+.stats-chart .ff-chip[data-on='0'] {
+    opacity: 0.5;
+    background: transparent;
+    text-decoration: line-through;
+}
+
+.stats-chart .ff-chip .ff-swatch {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+.stats-chart .ff-chip[data-on='0'] .ff-swatch {
+    opacity: 0.35;
+}
+
+/* Pick-one segmented control (Stack by / Show) — a connected pill with a filled
+   active segment; unmistakably a toggle, unlike faded text. */
+.stats-chart .ff-segmented {
+    display: inline-flex;
+    gap: 2px;
+    padding: 2px;
+    border-radius: 9999px;
+    background: var(--color-base-200);
+    border: 1px solid var(--color-base-300);
+}
+
+.stats-chart .ff-seg {
+    border: none;
+    background: transparent;
+    color: var(--color-base-content);
+    font-size: 0.72rem;
+    line-height: 1.4;
+    padding: 0.14rem 0.7rem;
+    border-radius: 9999px;
+    cursor: pointer;
+    opacity: 0.65;
+    transition: background 0.12s ease, color 0.12s ease, opacity 0.12s ease;
+}
+
+.stats-chart .ff-seg:hover {
+    opacity: 1;
+}
+
+.stats-chart .ff-seg[data-on='1'] {
+    background: var(--color-primary);
+    color: var(--color-primary-content);
+    opacity: 1;
+    font-weight: 600;
+}
+
+.stats-chart .ff-seg:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+}
+
+/* Side-by-side charts (Sailor ages / award funnel): reserve a common chart
+   height so the two cards line up at the bottom (items-start keeps a data-table
+   expansion from shoving its neighbour). */
+.stats-duo .stats-chart {
+    min-height: 280px;
+}
+
+/* Single "Reset" control, top-right of a toggleable chart's card. Muted text
+   button that restores all filters (and stack/mode) to their defaults. */
+.stats-reset {
+    position: absolute;
+    top: 1.15rem;
+    right: 1.4rem;
+    z-index: 2;
+    padding: 0.15rem 0.3rem;
+    font-size: 0.72rem;
+    line-height: 1;
+    color: var(--color-base-content);
+    background: none;
+    border: none;
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 0.12s ease;
+}
+
+.stats-reset:hover {
+    opacity: 1;
+    text-decoration: underline;
+}
+
+.stats-reset:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+    opacity: 1;
+}
+
+/* Filters applied → the reset is actionable, so surface it. */
+.stats-reset[data-active='1'] {
+    opacity: 1;
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+/* Heatmap "Less → More" scale — a centred row under the grid */
+.stats-chart .chart-heat-legend {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3rem;
+    margin-top: 0.5rem;
+    font-size: 0.7rem;
+    color: var(--color-base-content);
+    opacity: 0.7;
+}
+
+.stats-chart .chart-heat-legend .heat-swatch {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 2px;
+}
+
+.stats-chart .chart-tooltip {
+    position: absolute;
+    pointer-events: none;
+    z-index: 10;
+    background: var(--color-neutral);
+    color: var(--color-neutral-content);
+    border-radius: 0.375rem;
+    padding: 0.375rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    opacity: 0;
+    transition: opacity 0.1s ease;
+    max-width: 16rem;
+    white-space: nowrap;
+}
+
+.stats-chart .chart-tooltip.visible {
+    opacity: 1;
+}
+
+.stats-chart .chart-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem 1rem;
+    font-size: 0.75rem;
+    color: var(--color-base-content);
+    margin-bottom: 0.375rem;
+}
+
+.stats-chart .chart-legend .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.stats-chart .chart-legend .legend-swatch {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 0.125rem;
+    flex-shrink: 0;
+}
+
+.stats-chart .chart-empty {
+    padding: 2.5rem 1rem;
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--color-base-content);
+    opacity: 0.6;
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,3 +6,4 @@ import './toast';
 import './sailor-logs';
 import './password-toggle';
 import './verification-banner';
+import './stats-charts';

--- a/resources/js/stats-charts.js
+++ b/resources/js/stats-charts.js
@@ -1,0 +1,993 @@
+// D3 charts for the public Community Stats page (/stats).
+//
+// Data flow: App\Livewire\CommunityStats embeds the initial payload in a JSON
+// script tag (#community-stats-data) and dispatches the browser event
+// 'community-stats-updated' with a fresh payload when the year changes.
+// Chart containers live inside wire:ignore blocks, so Livewire never touches
+// the D3-owned DOM. Every chart has a server-rendered table twin in the Blade
+// view, so no value is reachable only by hovering.
+
+import { select } from 'd3-selection';
+import { scaleBand, scaleLinear } from 'd3-scale';
+import { max } from 'd3-array';
+import { area, curveMonotoneX, stack, stackOffsetExpand } from 'd3-shape';
+
+// Palette validated with the dataviz six-checks validator against the
+// base-100 card surface (#f0f2f4). Magenta/yellow sit below 3:1 contrast;
+// the relief channel is the legend + tooltips + table views.
+const COLORS = {
+    ordinal: ['#6da7ec', '#2a78d6', '#1c5cab', '#0d366b'], // funnel, light→dark
+    heat: ['#9ec5f4', '#6da7ec', '#3987e5', '#256abf', '#0d366b'],
+    heatZero: '#e2e5e8', // base-200: a day with no flashes
+    // Gender: conventional blue/pink split; non-binary gets a distinct green,
+    // undisclosed a neutral gray (omitted from the public chart anyway).
+    gender: {
+        male: '#2a78d6',
+        female: '#e87ba4',
+        non_binary: '#008300',
+        prefer_not_to_say: '#898781',
+    },
+    surface: '#f0f2f4', // base-100: gaps and rings are this color
+    grid: '#dde2e7',
+    axis: '#c6ccd2',
+    text: '#5a6570',
+};
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+// Trailing window for the cumulative-chart tooltips' "growth vs N days ago".
+const GROWTH_WINDOW_DAYS = 30;
+// Finest-grained flash categories for the cumulative area (stack order + hues).
+const FLASH_CATEGORIES = [
+    { key: 'regatta', label: 'Regatta', color: '#2a78d6' },
+    { key: 'club_race', label: 'Club Race', color: '#008300' },
+    { key: 'practice', label: 'Practice', color: '#e87ba4' },
+    { key: 'leisure', label: 'Day Sailing', color: '#eda100' },
+    { key: 'maintenance', label: 'Maintenance', color: '#1baf7a' },
+    { key: 'race_committee', label: 'Race Committee', color: '#4a3aa7' },
+];
+
+let currentPayload = null;
+
+// ---------------------------------------------------------------------------
+// Bootstrapping
+// ---------------------------------------------------------------------------
+
+function initStatsCharts() {
+    const dataEl = document.getElementById('community-stats-data');
+    if (!dataEl) {
+        return;
+    }
+
+    try {
+        currentPayload = JSON.parse(dataEl.textContent);
+    } catch {
+        return;
+    }
+
+    renderAll();
+}
+
+document.addEventListener('DOMContentLoaded', initStatsCharts);
+document.addEventListener('livewire:navigated', initStatsCharts);
+
+document.addEventListener('livewire:init', () => {
+    window.Livewire.on('community-stats-updated', (event) => {
+        const data = Array.isArray(event) ? event[0] : event;
+        if (data && data.payload) {
+            currentPayload = data.payload;
+            renderAll();
+        }
+    });
+});
+
+let resizeTimer;
+window.addEventListener('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => renderAll(), 150);
+});
+
+function renderAll() {
+    if (!currentPayload) {
+        return;
+    }
+
+    renderHeatmap();
+    renderSailorGrowth();
+    renderFlashFilter();
+    renderAges();
+    renderFunnel();
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function chartContainer(id) {
+    const el = document.getElementById(id);
+    if (el) {
+        el.replaceChildren();
+    }
+    return el;
+}
+
+function emptyMessage(el, text) {
+    const div = document.createElement('div');
+    div.className = 'chart-empty';
+    div.textContent = text;
+    el.appendChild(div);
+}
+
+function makeTooltip(el) {
+    const tip = document.createElement('div');
+    tip.className = 'chart-tooltip';
+    el.appendChild(tip);
+
+    return {
+        show(event, rows) {
+            tip.replaceChildren();
+            rows.forEach((row) => {
+                const line = document.createElement('div');
+                if (row.swatch) {
+                    const key = document.createElement('span');
+                    key.style.display = 'inline-block';
+                    key.style.width = '10px';
+                    key.style.height = '3px';
+                    key.style.borderRadius = '1px';
+                    key.style.verticalAlign = 'middle';
+                    key.style.marginRight = '5px';
+                    key.style.background = row.swatch;
+                    line.appendChild(key);
+                }
+                const value = document.createElement('strong');
+                value.textContent = row.value;
+                line.appendChild(value);
+                if (row.label) {
+                    line.appendChild(document.createTextNode(` ${row.label}`));
+                }
+                if (row.sub) {
+                    const sub = document.createElement('span');
+                    sub.textContent = `  ${row.sub}`;
+                    sub.style.opacity = '0.6';
+                    line.appendChild(sub);
+                }
+                tip.appendChild(line);
+            });
+            tip.classList.add('visible');
+            this.move(event);
+        },
+        move(event) {
+            const bounds = el.getBoundingClientRect();
+            const x = event.clientX - bounds.left;
+            const y = event.clientY - bounds.top;
+            const tipWidth = tip.offsetWidth;
+            const left = Math.max(0, Math.min(x + 12, el.clientWidth - tipWidth - 4));
+            const top = y - tip.offsetHeight - 10;
+            tip.style.left = `${left}px`;
+            tip.style.top = `${top < 0 ? y + 14 : top}px`;
+        },
+        hide() {
+            tip.classList.remove('visible');
+        },
+    };
+}
+
+function makeLegend(el, items) {
+    const legend = document.createElement('div');
+    legend.className = 'chart-legend';
+    items.forEach((item) => {
+        const entry = document.createElement('span');
+        entry.className = 'legend-item';
+        const swatch = document.createElement('span');
+        swatch.className = 'legend-swatch';
+        swatch.style.background = item.color;
+        entry.appendChild(swatch);
+        entry.appendChild(document.createTextNode(item.label));
+        legend.appendChild(entry);
+    });
+    el.appendChild(legend);
+    return legend;
+}
+
+// Pick-one control rendered as a connected segmented control (label + pill of
+// mutually-exclusive segments; the active one is filled). onSelect(key) fires
+// on change. Distinct from filterChip(), which is a multi-select on/off toggle.
+function segmentedRadio(title, options, current, onSelect) {
+    const wrap = document.createElement('div');
+    wrap.className = 'flash-filter-group';
+    const label = document.createElement('span');
+    label.className = 'ff-group-label';
+    label.textContent = title;
+    wrap.appendChild(label);
+    const seg = document.createElement('div');
+    seg.className = 'ff-segmented';
+    seg.setAttribute('role', 'radiogroup');
+    seg.setAttribute('aria-label', title);
+    options.forEach((opt) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'ff-seg';
+        btn.setAttribute('role', 'radio');
+        btn.dataset.on = current === opt.key ? '1' : '0';
+        btn.setAttribute('aria-checked', current === opt.key ? 'true' : 'false');
+        btn.textContent = opt.label;
+        btn.addEventListener('click', () => {
+            [...seg.querySelectorAll('.ff-seg')].forEach((c, i) => {
+                const on = options[i].key === opt.key;
+                c.dataset.on = on ? '1' : '0';
+                c.setAttribute('aria-checked', on ? 'true' : 'false');
+            });
+            onSelect(opt.key);
+        });
+        seg.appendChild(btn);
+    });
+    wrap.appendChild(seg);
+    return wrap;
+}
+
+// Multi-select on/off toggle pill with an optional colour swatch. Starts on;
+// clicking toggles state.set membership and calls onChange(). Distinct from
+// segmentedRadio() (pick-one).
+function filterChip(label, swatchColor, initiallyOn, onToggle) {
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'ff-chip';
+    chip.dataset.on = initiallyOn ? '1' : '0';
+    chip.setAttribute('aria-pressed', initiallyOn ? 'true' : 'false');
+    if (swatchColor) {
+        const sw = document.createElement('span');
+        sw.className = 'ff-swatch';
+        sw.style.background = swatchColor;
+        chip.appendChild(sw);
+    }
+    chip.appendChild(document.createTextNode(label));
+    chip.addEventListener('click', () => {
+        const on = chip.dataset.on === '1' ? false : true;
+        chip.dataset.on = on ? '1' : '0';
+        chip.setAttribute('aria-pressed', on ? 'true' : 'false');
+        onToggle(on);
+    });
+    return chip;
+}
+
+// Mount a single "Reset" control in the top-right of the chart's card. Clicking
+// re-invokes the chart's render fn, which rebuilds it with default (all-on)
+// state — the filter state is local to that fn, so re-running is the reset.
+// Re-render-safe: a prior Reset (from a year change) is removed first.
+function mountReset(el, rerender) {
+    const card = el.closest('.card');
+    if (!card) {
+        return;
+    }
+    card.style.position = 'relative';
+    card.querySelector(':scope > .stats-reset')?.remove();
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'stats-reset';
+    btn.dataset.active = '0';
+    btn.textContent = 'Reset';
+    btn.title = 'Reset filters to default';
+    btn.addEventListener('click', rerender);
+    card.appendChild(btn);
+    return btn;
+}
+
+// Bar with a 4px rounded data-end and a square baseline
+function roundedTopBar(x, y, width, height, radius) {
+    const r = Math.min(radius, width / 2, height);
+    if (height <= 0) {
+        return '';
+    }
+    return [
+        `M${x},${y + height}`,
+        `L${x},${y + r}`,
+        `Q${x},${y} ${x + r},${y}`,
+        `L${x + width - r},${y}`,
+        `Q${x + width},${y} ${x + width},${y + r}`,
+        `L${x + width},${y + height}`,
+        'Z',
+    ].join(' ');
+}
+
+function makeSvg(el, width, height, label) {
+    return select(el)
+        .append('svg')
+        .attr('width', width)
+        .attr('height', height)
+        .attr('role', 'img')
+        .attr('aria-label', label);
+}
+
+// Horizontal hairline gridlines + tick labels for a linear y scale
+function drawYAxis(svg, y, ticks, left, right, format = (v) => v.toLocaleString()) {
+    ticks.forEach((tick) => {
+        svg.append('line')
+            .attr('x1', left)
+            .attr('x2', right)
+            .attr('y1', y(tick))
+            .attr('y2', y(tick))
+            .attr('stroke', tick === 0 ? COLORS.axis : COLORS.grid)
+            .attr('stroke-width', 1);
+        svg.append('text')
+            .attr('x', left - 6)
+            .attr('y', y(tick))
+            .attr('dy', '0.32em')
+            .attr('text-anchor', 'end')
+            .attr('font-size', 10)
+            .attr('fill', COLORS.text)
+            .text(format(tick));
+    });
+}
+
+// Stacked column chart (monthly by activity type, ages by gender). series is
+// bottom→top: [{key, label, color, values: [n per label]}]. Adds its own
+// legend; the per-band hit target covers the x-label too, and headerFor(i)
+// supplies the tooltip's leading row(s).
+function drawStackedColumn(el, { labels, series, height = 240, ariaLabel, headerFor, totalUnit = 'item' }) {
+    if (series.length > 0) {
+        makeLegend(el, series.map((s) => ({ color: s.color, label: s.label })));
+    }
+
+    const width = el.clientWidth || 340;
+    const margin = { top: 8, right: 8, bottom: 24, left: 30 };
+    const plotWidth = width - margin.left - margin.right;
+    const plotHeight = height - margin.top - margin.bottom;
+
+    const svg = makeSvg(el, width, height, ariaLabel);
+    const tooltip = makeTooltip(el);
+
+    const totals = labels.map((_, i) => series.reduce((sum, s) => sum + (s.values[i] || 0), 0));
+
+    const x = scaleBand().domain(labels).range([margin.left, margin.left + plotWidth]).paddingInner(0.35).paddingOuter(0.12);
+    const y = scaleLinear().domain([0, Math.max(1, max(totals))]).nice().range([margin.top + plotHeight, margin.top]);
+
+    drawYAxis(svg, y, y.ticks(4), margin.left, margin.left + plotWidth);
+
+    labels.forEach((lab) => {
+        svg.append('text')
+            .attr('x', x(lab) + x.bandwidth() / 2)
+            .attr('y', margin.top + plotHeight + 16)
+            .attr('text-anchor', 'middle')
+            .attr('font-size', 10)
+            .attr('fill', COLORS.text)
+            .text(lab);
+    });
+
+    const barWidth = Math.min(28, x.bandwidth());
+    const gap = 0; // segments touch — no separator lines between categories
+
+    labels.forEach((lab, i) => {
+        const barX = x(lab) + (x.bandwidth() - barWidth) / 2;
+        const segs = series.map((s) => ({ ...s, v: s.values[i] || 0 })).filter((s) => s.v > 0);
+        let cumulative = 0;
+        const bars = [];
+        segs.forEach((s, si) => {
+            const bottomY = y(cumulative);
+            const isTop = si === segs.length - 1;
+            const topY = y(cumulative + s.v) + (isTop ? 0 : gap);
+            const h = bottomY - topY;
+            let mark;
+            if (isTop && h > 0) {
+                mark = svg.append('path').attr('d', roundedTopBar(barX, topY, barWidth, h, 4)).attr('fill', s.color);
+            } else if (h > 0) {
+                mark = svg.append('rect').attr('x', barX).attr('y', topY).attr('width', barWidth).attr('height', h).attr('fill', s.color);
+            }
+            if (mark) {
+                bars.push(mark);
+            }
+            cumulative += s.v;
+        });
+
+        svg.append('rect')
+            .attr('x', x(lab)).attr('y', margin.top)
+            .attr('width', x.bandwidth()).attr('height', plotHeight + margin.bottom)
+            .attr('fill', 'transparent')
+            .on('pointerenter pointermove', (event) => {
+                bars.forEach((b) => b.attr('opacity', 0.8));
+                tooltip.show(event, [
+                    ...(headerFor ? headerFor(i) : [{ value: lab, label: '' }]),
+                    ...segs.map((s) => ({ swatch: s.color, value: s.v.toLocaleString(), label: s.label })),
+                    { value: totals[i].toLocaleString(), label: `${totalUnit}${totals[i] === 1 ? '' : 's'} total` },
+                ]);
+            })
+            .on('pointerleave', () => {
+                bars.forEach((b) => b.attr('opacity', 1));
+                tooltip.hide();
+            });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// D. Activity heatmap (GitHub contribution style)
+// ---------------------------------------------------------------------------
+
+function renderHeatmap() {
+    const el = chartContainer('chart-heatmap');
+    if (!el) {
+        return;
+    }
+
+    const { heatmap, year } = currentPayload;
+    const counts = heatmap || {};
+    const maxCount = max(Object.values(counts)) || 0;
+
+    if (maxCount === 0) {
+        emptyMessage(el, `No flashes logged in ${year} yet.`);
+        return;
+    }
+
+    const labelLeft = 28;
+    const labelTop = 16;
+    const rightPad = 6;
+
+    const jan1 = new Date(Date.UTC(year, 0, 1));
+    const dec31 = new Date(Date.UTC(year, 11, 31));
+    const firstDayOffset = jan1.getUTCDay();
+
+    // Only weeks up to today are painted (a mid-season year stops in July), so
+    // size the grid to what's actually shown rather than the full 53 weeks —
+    // otherwise the right half is blank and the grid looks left-shoved.
+    // Use UTC throughout so the last painted day matches the UTC day loop below.
+    // (Mixing local getDate() here with the loop's UTC dates clipped the heatmap a
+    // day short around timezone boundaries — US offsets are negative, so local
+    // lags UTC for several evening hours.)
+    const today = new Date();
+    const todayISO = today.toISOString().slice(0, 10);
+    const lastDay = year < today.getUTCFullYear() ? dec31 : new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+    const lastDayOfYear = Math.round((lastDay - jan1) / 86400000);
+    const weeksShown = Math.floor((lastDayOfYear + firstDayOffset) / 7) + 1;
+
+    // Size cells to fit the container width (so the grid fits without a
+    // scrollbar on normal screens); clamp for looks and fall back to scroll
+    // only on very narrow viewports.
+    const avail = el.clientWidth || 680;
+    const cell = Math.max(9, Math.min(15, Math.floor((avail - labelLeft - rightPad) / weeksShown) - 3));
+    const pitch = cell + 3;
+
+    const width = labelLeft + weeksShown * pitch + rightPad;
+    const height = labelTop + 7 * pitch + 8;
+
+    const scroll = document.createElement('div');
+    scroll.className = 'chart-scroll';
+    // Centre when the grid fits; only scroll when it genuinely overflows.
+    if (width <= avail) {
+        scroll.style.textAlign = 'center';
+        scroll.style.overflowX = 'visible';
+    }
+    el.appendChild(scroll);
+
+    const svg = makeSvg(scroll, width, height, `Daily activity heatmap for ${year}`).style('display', 'inline-block');
+    const tooltip = makeTooltip(el);
+
+    // Day-of-week labels
+    [['Mon', 1], ['Wed', 3], ['Fri', 5]].forEach(([label, row]) => {
+        svg.append('text')
+            .attr('x', labelLeft - 6)
+            .attr('y', labelTop + row * pitch + cell / 2)
+            .attr('dy', '0.32em')
+            .attr('text-anchor', 'end')
+            .attr('font-size', 9)
+            .attr('fill', COLORS.text)
+            .text(label);
+    });
+
+    let lastMonthLabelled = -1;
+
+    for (let date = new Date(jan1); date <= dec31; date.setUTCDate(date.getUTCDate() + 1)) {
+        const iso = date.toISOString().slice(0, 10);
+        if (iso > todayISO) {
+            break;
+        }
+
+        const dayOfYear = Math.round((date - jan1) / 86400000);
+        const week = Math.floor((dayOfYear + firstDayOffset) / 7);
+        const dow = date.getUTCDay();
+        const count = counts[iso] || 0;
+
+        // Month label above the first week of each month
+        const month = date.getUTCMonth();
+        if (month !== lastMonthLabelled && date.getUTCDate() <= 7 && dow === 0 || (month !== lastMonthLabelled && dayOfYear === 0)) {
+            svg.append('text')
+                .attr('x', labelLeft + week * pitch)
+                .attr('y', labelTop - 5)
+                .attr('font-size', 9)
+                .attr('fill', COLORS.text)
+                .text(MONTHS[month]);
+            lastMonthLabelled = month;
+        }
+
+        const fill = count === 0
+            ? COLORS.heatZero
+            : COLORS.heat[Math.min(COLORS.heat.length - 1, Math.floor(((count - 1) / maxCount) * COLORS.heat.length))];
+
+        const displayDate = `${MONTHS[month]} ${date.getUTCDate()}`;
+
+        svg.append('rect')
+            .attr('x', labelLeft + week * pitch)
+            .attr('y', labelTop + dow * pitch)
+            .attr('width', cell)
+            .attr('height', cell)
+            .attr('rx', 2)
+            .attr('fill', fill)
+            .on('pointerenter pointermove', function (event) {
+                select(this).attr('stroke', COLORS.text).attr('stroke-width', 1);
+                tooltip.show(event, [{
+                    value: `${count} ${count === 1 ? 'flash' : 'flashes'}`,
+                    label: `on ${displayDate}`,
+                }]);
+            })
+            .on('pointerleave', function () {
+                select(this).attr('stroke', null);
+                tooltip.hide();
+            });
+    }
+
+    // "Less → More" scale, as a clean centred row below the grid
+    const legend = document.createElement('div');
+    legend.className = 'chart-heat-legend';
+    const less = document.createElement('span');
+    less.textContent = 'Less';
+    legend.appendChild(less);
+    [COLORS.heatZero, ...COLORS.heat].forEach((color) => {
+        const sw = document.createElement('span');
+        sw.className = 'heat-swatch';
+        sw.style.background = color;
+        legend.appendChild(sw);
+    });
+    const more = document.createElement('span');
+    more.textContent = 'More';
+    legend.appendChild(more);
+    el.appendChild(legend);
+}
+
+// ---------------------------------------------------------------------------
+// F2. Community growth — cumulative sailors, stackable by gender or age
+// ---------------------------------------------------------------------------
+
+function dayOfYear(dateStr, year) {
+    return Math.round((Date.parse(`${dateStr}T00:00:00Z`) - Date.UTC(year, 0, 1)) / 86400000);
+}
+
+// Age groups use an ordinal blue ramp (young → old); unknown a neutral gray.
+const GROWTH_AGE_COLORS = { youth: '#9ec5f4', u32: '#6da7ec', mid: '#3987e5', masters: '#0d366b', unknown: '#898781' };
+
+function renderSailorGrowth() {
+    const el = chartContainer('chart-cumulative');
+    if (!el) {
+        return;
+    }
+
+    const { year, sailorGrowth } = currentPayload;
+    if (!sailorGrowth || !sailorGrowth.rows || sailorGrowth.rows.length === 0) {
+        emptyMessage(el, `Not enough signups yet to chart ${year} growth.`);
+        return;
+    }
+
+    const dims = {
+        gender: { label: 'Gender', field: 'gender', values: sailorGrowth.genders, color: (k) => COLORS.gender[k] || COLORS.text },
+        age: { label: 'Age', field: 'ageGroup', values: sailorGrowth.ageGroups, color: (k) => GROWTH_AGE_COLORS[k] || COLORS.text },
+    };
+
+    const state = {
+        // Default to age: it maps to the class's youth/U32 growth goal, gives
+        // four meaningful bands (vs a male-skewed gender split), and pairs with
+        // the age×gender snapshot in the Sailor ages chart. Gender is a toggle.
+        stackBy: 'age',
+        mode: 'count',
+        active: {
+            gender: new Set(sailorGrowth.genders.map((g) => g.key)),
+            age: new Set(sailorGrowth.ageGroups.map((a) => a.key)),
+        },
+    };
+
+    const controls = document.createElement('div');
+    controls.className = 'flash-filter-controls';
+
+    controls.appendChild(segmentedRadio('Stack by', [{ key: 'age', label: 'Age' }, { key: 'gender', label: 'Gender' }], state.stackBy, (k) => {
+        state.stackBy = k;
+        buildValueChips();
+        draw();
+    }));
+    controls.appendChild(segmentedRadio('Show', [{ key: 'count', label: 'Count' }, { key: 'percent', label: 'Share %' }], state.mode, (k) => {
+        state.mode = k;
+        draw();
+    }));
+
+    // Value chips for the current stack dimension (rebuilt when it changes)
+    const valueWrap = document.createElement('div');
+    valueWrap.className = 'flash-filter-group';
+    controls.appendChild(valueWrap);
+
+    function buildValueChips() {
+        valueWrap.replaceChildren();
+        const dim = dims[state.stackBy];
+        const label = document.createElement('span');
+        label.className = 'ff-group-label';
+        label.textContent = dim.label;
+        valueWrap.appendChild(label);
+        dim.values.forEach((item) => {
+            const set = state.active[state.stackBy];
+            valueWrap.appendChild(filterChip(item.label, dim.color(item.key), set.has(item.key), (on) => {
+                if (on) {
+                    set.add(item.key);
+                } else {
+                    set.delete(item.key);
+                }
+                draw();
+            }));
+        });
+    }
+    buildValueChips();
+
+    el.appendChild(controls);
+    const chartDiv = document.createElement('div');
+    chartDiv.className = 'stats-chart';
+    el.appendChild(chartDiv);
+
+    // "Filters active" = a band toggled off in either stack dimension.
+    let resetBtn = null;
+    const isFiltered = () => state.active.gender.size !== sailorGrowth.genders.length
+        || state.active.age.size !== sailorGrowth.ageGroups.length;
+
+    function draw() {
+        const dim = dims[state.stackBy];
+        const activeSet = state.active[state.stackBy];
+        const cats = dim.values.filter((v) => activeSet.has(v.key)).map((v) => ({ key: v.key, label: v.label, color: dim.color(v.key) }));
+        const rows = sailorGrowth.rows
+            .filter((r) => activeSet.has(r[dim.field]))
+            .map((r) => ({ date: r.date, category: r[dim.field], count: r.count }));
+        const points = cumulateByCategory(rows, cats, year);
+        drawStackedArea(chartDiv, points, cats, year, `Community growth by ${state.stackBy}, ${year}`, state.mode === 'percent');
+        if (resetBtn) {
+            resetBtn.dataset.active = isFiltered() ? '1' : '0';
+        }
+    }
+    draw();
+    resetBtn = mountReset(el, renderSailorGrowth);
+}
+
+// ---------------------------------------------------------------------------
+// F3. Cumulative flashes by category — stacked area, running totals
+// ---------------------------------------------------------------------------
+
+// Cumulate daily category rows [{date, category, count}] into stacked points
+// [{date, day, <catKey>: runningTotal}], seeded with a year-start baseline.
+function cumulateByCategory(rows, cats, year) {
+    const byDate = new Map();
+    rows.forEach((r) => {
+        if (!byDate.has(r.date)) {
+            byDate.set(r.date, {});
+        }
+        const d = byDate.get(r.date);
+        d[r.category] = (d[r.category] || 0) + r.count;
+    });
+
+    const dates = [...byDate.keys()].sort();
+    const running = {};
+    cats.forEach((c) => { running[c.key] = 0; });
+
+    const points = [];
+    if (dates.length === 0 || dates[0] !== `${year}-01-01`) {
+        points.push({ date: `${year}-01-01`, day: dayOfYear(`${year}-01-01`, year), ...running });
+    }
+    dates.forEach((date) => {
+        const d = byDate.get(date);
+        cats.forEach((c) => { running[c.key] += d[c.key] || 0; });
+        points.push({ date, day: dayOfYear(date, year), ...running });
+    });
+    return points;
+}
+
+// Trailing-window momentum text for a cumulative value: how much it gained over
+// the last GROWTH_WINDOW_DAYS, plus a % vs then. Guards the pitfalls of a %-change
+// on a cumulative series — a zero base reads "new" (not ∞), and a tiny base drops
+// the % (avoids "+2 → 200%" whiplash early in the season). Returns null when there
+// is nothing to say. Compact by design; the tooltip's caption row states the window.
+function growthText(current, base) {
+    if (current === 0) {
+        return null;
+    }
+    const delta = current - base;
+    if (delta === 0) {
+        return 'flat';
+    }
+    const gain = `+${delta.toLocaleString()}`;
+    // base 0 → brand new; base < 5 → too small for a meaningful %
+    const rate = base === 0 ? 'new' : base < 5 ? null : `▲${Math.round((delta / base) * 100)}%`;
+    return rate ? `${gain} ${rate}` : gain;
+}
+
+// Draw a cumulative stacked area into `el` from pre-cumulated points and the
+// active category list [{key, label, color}]. Shared by the plain and the
+// filterable cumulative-flashes charts.
+function drawStackedArea(el, points, cats, year, ariaLabel, normalize = false) {
+    el.replaceChildren();
+
+    // In % mode the expand offset divides by the per-date total, so drop any
+    // leading zero-total points (the year-start baseline) to avoid NaN.
+    const totalAt = (p) => cats.reduce((sum, c) => sum + (p[c.key] || 0), 0);
+    const pts = normalize ? points.filter((p) => totalAt(p) > 0) : points;
+
+    if (pts.length < 2 || cats.length === 0) {
+        emptyMessage(el, 'Nothing to show — turn a filter back on.');
+        return;
+    }
+
+    const last = pts[pts.length - 1];
+    const width = el.clientWidth || 600;
+    const height = 260;
+    const margin = { top: 12, right: 48, bottom: 24, left: 38 };
+    const plotWidth = width - margin.left - margin.right;
+    const plotHeight = height - margin.top - margin.bottom;
+
+    const svg = makeSvg(el, width, height, ariaLabel);
+    const tooltip = makeTooltip(el);
+
+    const lastDay = last.day;
+    const totalMax = totalAt(last);
+    const x = scaleLinear().domain([0, Math.max(1, lastDay)]).range([margin.left, margin.left + plotWidth]);
+    const y = normalize
+        ? scaleLinear().domain([0, 1]).range([margin.top + plotHeight, margin.top])
+        : scaleLinear().domain([0, Math.max(1, totalMax)]).nice().range([margin.top + plotHeight, margin.top]);
+
+    drawYAxis(svg, y, normalize ? [0, 0.5, 1] : y.ticks(4), margin.left, margin.left + plotWidth, normalize ? (v) => `${Math.round(v * 100)}%` : undefined);
+
+    const lastMonth = new Date(Date.UTC(year, 0, 1) + lastDay * 86400000).getUTCMonth();
+    for (let m = 0; m <= lastMonth; m++) {
+        const monthDay = dayOfYear(`${year}-${String(m + 1).padStart(2, '0')}-01`, year);
+        svg.append('text')
+            .attr('x', x(monthDay)).attr('y', margin.top + plotHeight + 16)
+            .attr('text-anchor', 'middle').attr('font-size', 10).attr('fill', COLORS.text)
+            .text(MONTHS[m]);
+    }
+
+    const series = stack().keys(cats.map((c) => c.key));
+    if (normalize) {
+        series.offset(stackOffsetExpand);
+    }
+    const stacked = series(pts);
+    const areaGen = area().x((d) => x(d.data.day)).y0((d) => y(d[0])).y1((d) => y(d[1])).curve(curveMonotoneX);
+    stacked.forEach((layer, i) => {
+        svg.append('path')
+            .attr('d', areaGen(layer))
+            .attr('fill', cats[i].color)
+            .attr('stroke', COLORS.surface)
+            .attr('stroke-width', 1)
+            .attr('stroke-linejoin', 'round');
+    });
+
+    if (!normalize) {
+        svg.append('text')
+            .attr('x', x(lastDay) + 8).attr('y', y(totalMax)).attr('dy', '0.32em')
+            .attr('font-size', 11).attr('font-weight', 600).attr('fill', COLORS.text)
+            .text(totalMax.toLocaleString());
+    }
+
+    const crosshair = svg.append('line')
+        .attr('y1', margin.top).attr('y2', margin.top + plotHeight)
+        .attr('stroke', COLORS.text).attr('stroke-width', 1).attr('opacity', 0);
+
+    svg.append('rect')
+        .attr('x', margin.left).attr('y', margin.top)
+        .attr('width', plotWidth).attr('height', plotHeight)
+        .attr('fill', 'transparent')
+        .on('pointerenter pointermove', (event) => {
+            const bounds = el.getBoundingClientRect();
+            const hoverDay = Math.max(0, Math.min(lastDay, Math.round(x.invert(event.clientX - bounds.left))));
+            const pointAt = (day) => pts.filter((p) => p.day <= day).pop();
+            const asOf = pointAt(hoverDay) || pts[0];
+            const prior = pointAt(hoverDay - GROWTH_WINDOW_DAYS); // 30-day-trailing baseline (undefined before it exists)
+            const date = new Date(Date.UTC(year, 0, 1) + hoverDay * 86400000);
+            const total = totalAt(asOf);
+            crosshair.attr('x1', x(hoverDay)).attr('x2', x(hoverDay)).attr('opacity', 1);
+            tooltip.show(event, [
+                // Caption row: the date, plus what the +/▲ figures below mean.
+                { value: `${MONTHS[date.getUTCMonth()]} ${date.getUTCDate()}`, sub: `change vs ${GROWTH_WINDOW_DAYS} days ago` },
+                // Total on its own row, aligned with the bands.
+                { value: total.toLocaleString(), label: 'Total', sub: growthText(total, prior ? totalAt(prior) : 0) },
+                ...cats.map((c) => {
+                    const n = asOf[c.key] || 0;
+                    const val = normalize ? `${total ? Math.round((n / total) * 100) : 0}%` : n.toLocaleString();
+                    return { swatch: c.color, value: val, label: c.label, sub: growthText(n, prior ? prior[c.key] || 0 : 0) };
+                }),
+            ]);
+        })
+        .on('pointerleave', () => {
+            crosshair.attr('opacity', 0);
+            tooltip.hide();
+        });
+}
+
+// F4. Filterable cumulative flashes — toggle genders / age groups / activity
+function renderFlashFilter() {
+    const el = chartContainer('chart-flash-filter');
+    if (!el) {
+        return;
+    }
+
+    const { year, flashFilter } = currentPayload;
+    if (!flashFilter || !flashFilter.rows || flashFilter.rows.length === 0) {
+        emptyMessage(el, `No flashes to filter for ${year}.`);
+        return;
+    }
+
+    const catColor = Object.fromEntries(FLASH_CATEGORIES.map((c) => [c.key, c.color]));
+    const categories = flashFilter.categories.map((c) => ({ ...c, color: catColor[c.key] || COLORS.text }));
+
+    const state = {
+        gender: new Set(flashFilter.genders.map((g) => g.key)),
+        ageGroup: new Set(flashFilter.ageGroups.map((a) => a.key)),
+        category: new Set(categories.map((c) => c.key)),
+        mode: 'count',
+    };
+
+    const controls = document.createElement('div');
+    controls.className = 'flash-filter-controls';
+
+    // Count / Share (%) — pick-one segmented control
+    controls.appendChild(segmentedRadio('Show', [{ key: 'count', label: 'Count' }, { key: 'percent', label: 'Share %' }], state.mode, (k) => {
+        state.mode = k;
+        draw();
+    }));
+
+    const groups = [
+        { title: 'Activity', dim: 'category', items: categories, swatch: (k) => catColor[k] },
+        { title: 'Gender', dim: 'gender', items: flashFilter.genders },
+        { title: 'Age', dim: 'ageGroup', items: flashFilter.ageGroups },
+    ];
+
+    groups.forEach((group) => {
+        if (group.items.length < 2 && group.dim !== 'category') {
+            return; // a lone gender/age value isn't worth a toggle
+        }
+        const wrap = document.createElement('div');
+        wrap.className = 'flash-filter-group';
+        const label = document.createElement('span');
+        label.className = 'ff-group-label';
+        label.textContent = group.title;
+        wrap.appendChild(label);
+
+        group.items.forEach((item) => {
+            const set = state[group.dim];
+            wrap.appendChild(filterChip(item.label, group.swatch ? group.swatch(item.key) : null, set.has(item.key), (on) => {
+                if (on) {
+                    set.add(item.key);
+                } else {
+                    set.delete(item.key);
+                }
+                draw();
+            }));
+        });
+        controls.appendChild(wrap);
+    });
+    el.appendChild(controls);
+
+    const chartDiv = document.createElement('div');
+    chartDiv.className = 'stats-chart';
+    el.appendChild(chartDiv);
+
+    // "Filters active" = any activity / gender / age band toggled off.
+    let resetBtn = null;
+    const isFiltered = () => state.category.size !== categories.length
+        || state.gender.size !== flashFilter.genders.length
+        || state.ageGroup.size !== flashFilter.ageGroups.length;
+
+    function draw() {
+        const activeCats = categories.filter((c) => state.category.has(c.key));
+        const rows = flashFilter.rows.filter((r) => state.gender.has(r.gender) && state.ageGroup.has(r.ageGroup) && state.category.has(r.category));
+        const points = cumulateByCategory(rows, activeCats, year);
+        drawStackedArea(chartDiv, points, activeCats, year, `Cumulative flashes, filtered, ${year}`, state.mode === 'percent');
+        if (resetBtn) {
+            resetBtn.dataset.active = isFiltered() ? '1' : '0';
+        }
+    }
+    draw();
+    resetBtn = mountReset(el, renderFlashFilter);
+}
+
+// ---------------------------------------------------------------------------
+// G. Sailor age distribution
+// ---------------------------------------------------------------------------
+
+function renderAges() {
+    const el = chartContainer('chart-ages');
+    if (!el) {
+        return;
+    }
+
+    const { ages, year } = currentPayload;
+    const genders = ages.genders || [];
+    const labels = ages.labels || [];
+
+    const series = genders.map((g) => ({
+        key: g.key,
+        label: g.label,
+        color: COLORS.gender[g.key] || COLORS.text,
+        values: labels.map((lab) => (ages.counts[lab] || {})[g.key] || 0),
+    }));
+    const anyData = series.some((s) => s.values.some((v) => v > 0));
+
+    if (!anyData) {
+        emptyMessage(el, `No sailor ages to show for ${year}.`);
+        return;
+    }
+
+    drawStackedColumn(el, {
+        labels,
+        series,
+        height: 240,
+        ariaLabel: `Sailor ages by Lightning Class division and gender, ${year}`,
+        headerFor: (i) => [{ value: labels[i], label: `· ages ${ages.ranges[i]}` }],
+        totalUnit: 'sailor',
+    });
+}
+
+// ---------------------------------------------------------------------------
+// H. Award funnel — centred conversion funnel (registered → tiers)
+// ---------------------------------------------------------------------------
+
+function renderFunnel() {
+    const el = chartContainer('chart-funnel');
+    if (!el) {
+        return;
+    }
+
+    const { funnel, year } = currentPayload;
+    const top = funnel[0]?.count || 0; // registered = widest stage
+
+    if (top === 0) {
+        emptyMessage(el, `No registered sailors for ${year} yet.`);
+        return;
+    }
+
+    const width = el.clientWidth || 600;
+    const rowPitch = 52;
+    const barHeight = 26;
+    const topPad = 18;
+    const height = funnel.length * rowPitch + topPad;
+    const maxBar = width - 16;
+    const cx = width / 2;
+
+    const svg = makeSvg(el, width, height, `Award-progress funnel for ${year}`);
+    const tooltip = makeTooltip(el);
+
+    funnel.forEach((stage, i) => {
+        const rowY = topPad + i * rowPitch;
+        const barY = rowY + 14;
+        const w = Math.max(2, (stage.count / top) * maxBar);
+        const color = COLORS.heat[Math.min(i, COLORS.heat.length - 1)];
+        const pct = Math.round((stage.count / top) * 100);
+        const prev = i > 0 ? funnel[i - 1].count : null;
+        const stepPct = prev ? Math.round((stage.count / prev) * 100) : null;
+
+        // Stage label + count above the bar
+        svg.append('text')
+            .attr('x', cx)
+            .attr('y', rowY + 8)
+            .attr('text-anchor', 'middle')
+            .attr('font-size', 11)
+            .attr('fill', COLORS.text)
+            .text(`${stage.label} · ${stage.count.toLocaleString()}${i > 0 ? ` (${pct}% of registered)` : ''}`);
+
+        // Centred narrowing bar
+        if (stage.count > 0) {
+            svg.append('rect')
+                .attr('x', cx - w / 2).attr('y', barY)
+                .attr('width', w).attr('height', barHeight)
+                .attr('rx', 3).attr('fill', color);
+        }
+
+        // Full-row hit target
+        svg.append('rect')
+            .attr('x', 0).attr('y', rowY)
+            .attr('width', width).attr('height', rowPitch)
+            .attr('fill', 'transparent')
+            .on('pointerenter pointermove', (event) => {
+                const rows = [{ value: `${stage.count.toLocaleString()} ${stage.count === 1 ? 'sailor' : 'sailors'}`, label: stage.label }];
+                if (stepPct !== null) {
+                    rows.push({ value: `${stepPct}%`, label: `from ${prev.toLocaleString()} at "${funnel[i - 1].label}"` });
+                }
+                tooltip.show(event, rows);
+            })
+            .on('pointerleave', () => tooltip.hide());
+    });
+}

--- a/resources/views/admin/settings.blade.php
+++ b/resources/views/admin/settings.blade.php
@@ -1,0 +1,5 @@
+<x-layout>
+    <x-slot:title>Admin Settings</x-slot:title>
+
+    @livewire('admin-settings')
+</x-layout>

--- a/resources/views/components/chart-card.blade.php
+++ b/resources/views/components/chart-card.blade.php
@@ -1,0 +1,30 @@
+@props(['chartId', 'title', 'subtitle' => null])
+
+<div {{ $attributes->merge(['class' => 'card bg-base-100 shadow-md']) }}>
+    <div class="card-body">
+        <h2 class="card-title text-lg">{{ $title }}</h2>
+        @if ($subtitle)
+            <p class="text-sm opacity-70 -mt-1">{{ $subtitle }}</p>
+        @endif
+
+        {{-- D3 owns this subtree; Livewire must never morph it --}}
+        <div wire:ignore>
+            <div id="{{ $chartId }}" class="stats-chart" data-stats-chart></div>
+        </div>
+
+        {{-- Optional highlight caption below the chart (e.g. busiest day) --}}
+        @isset($caption)
+            <p class="text-sm text-base-content/70 mt-2">{{ $caption }}</p>
+        @endisset
+
+        {{-- Accessible, hover-free twin of the chart (updates with the year) --}}
+        @isset($table)
+            <details class="mt-2 text-sm">
+                <summary class="cursor-pointer opacity-70 hover:opacity-100 select-none">View data table</summary>
+                <div class="overflow-x-auto mt-2 max-h-72 overflow-y-auto">
+                    {{ $table }}
+                </div>
+            </details>
+        @endisset
+    </div>
+</div>

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -56,11 +56,15 @@
                 @auth
                     <li><a href="/logbook" class="text-base py-3 {{ str_starts_with(request()->path(), 'logbook') ? 'active font-bold text-accent' : '' }}">Logbook</a></li>
                 @endauth
+                <li><a href="/stats" class="text-base py-3 {{ str_starts_with(request()->path(), 'stats') ? 'active font-bold text-accent' : '' }}">Stats</a></li>
                 <li><a href="/leaderboard" class="text-base py-3 {{ str_starts_with(request()->path(), 'leaderboard') ? 'active font-bold text-accent' : '' }}">Leaderboard</a></li>
                 @auth
                     @if(auth()->user()->is_admin)
                         <li><a href="/admin/fulfillment" class="text-base py-3 {{ str_starts_with(request()->path(), 'admin/fulfillment') ? 'active font-bold text-accent' : '' }}">Award Fulfillment</a></li>
                         <li><a href="/admin/sailor-logs" class="text-base py-3 {{ str_starts_with(request()->path(), 'admin/sailor-logs') ? 'active font-bold text-accent' : '' }}">Sailor Logs</a></li>
+                    @endif
+                    @if(auth()->user()->isSuperAdmin())
+                        <li><a href="/admin/settings" class="text-base py-3 {{ str_starts_with(request()->path(), 'admin/settings') ? 'active font-bold text-accent' : '' }}">Settings</a></li>
                     @endif
                 @endauth
 
@@ -94,11 +98,15 @@
             @auth
                 <li><a href="/logbook" class="btn btn-ghost btn-sm hover:bg-white/10 {{ str_starts_with(request()->path(), 'logbook') ? '!text-white !font-bold underline decoration-accent decoration-2 underline-offset-4' : 'text-white/80' }}">Logbook</a></li>
             @endauth
+            <li><a href="/stats" class="btn btn-ghost btn-sm hover:bg-white/10 {{ str_starts_with(request()->path(), 'stats') ? '!text-white !font-bold underline decoration-accent decoration-2 underline-offset-4' : 'text-white/80' }}">Stats</a></li>
             <li><a href="/leaderboard" class="btn btn-ghost btn-sm hover:bg-white/10 {{ str_starts_with(request()->path(), 'leaderboard') ? '!text-white !font-bold underline decoration-accent decoration-2 underline-offset-4' : 'text-white/80' }}">Leaderboard</a></li>
             @auth
                 @if(auth()->user()->is_admin)
                     <li><a href="/admin/fulfillment" class="btn btn-ghost btn-sm hover:bg-white/10 {{ str_starts_with(request()->path(), 'admin/fulfillment') ? '!text-white !font-bold underline decoration-accent decoration-2 underline-offset-4' : 'text-white/80' }}">Award Fulfillment</a></li>
                     <li><a href="/admin/sailor-logs" class="btn btn-ghost btn-sm hover:bg-white/10 {{ str_starts_with(request()->path(), 'admin/sailor-logs') ? '!text-white !font-bold underline decoration-accent decoration-2 underline-offset-4' : 'text-white/80' }}">Sailor Logs</a></li>
+                @endif
+                @if(auth()->user()->isSuperAdmin())
+                    <li><a href="/admin/settings" class="btn btn-ghost btn-sm hover:bg-white/10 {{ str_starts_with(request()->path(), 'admin/settings') ? '!text-white !font-bold underline decoration-accent decoration-2 underline-offset-4' : 'text-white/80' }}">Settings</a></li>
                 @endif
             @endauth
         </ul>

--- a/resources/views/components/lightning-fill.blade.php
+++ b/resources/views/components/lightning-fill.blade.php
@@ -1,0 +1,42 @@
+@props([
+    'percentage' => null,       // current / goal, 0–100 (null = no goal set)
+    'priorPercentage' => null,  // prior-year total / goal, 0–100 (null/0 = hide line)
+    'goalLabel' => null,        // formatted goal, e.g. "3,000"
+    'priorYear' => null,        // e.g. 2025, for the benchmark chip
+])
+
+@php
+    $fill = $percentage === null ? 0 : max(0, min(100, $percentage));
+    $complete = $percentage !== null && $percentage >= 100;
+    $showPrior = $priorPercentage !== null && $priorPercentage > 0;
+    $priorFrac = $showPrior ? max(0, min(100, $priorPercentage)) / 100 : 0;
+@endphp
+
+<div {{ $attributes->merge(['class' => 'lightning-fill'.($complete ? ' lightning-fill-complete' : '')]) }}
+     style="--lf-fill: {{ $fill }}%; --lf-prior: {{ $priorFrac }};"
+     role="img"
+     aria-label="Community goal progress: {{ $percentage === null ? 'no goal set' : round($fill).'% of goal' }}{{ $showPrior && $priorYear ? ', '.$priorYear.' benchmark shown' : '' }}">
+    @if ($goalLabel !== null)
+        <div class="lightning-fill-goal">{{ $goalLabel }} <span>goal</span></div>
+    @endif
+
+    <div class="lightning-fill-circle">
+        {{-- The bolt silhouette (Lightning Class insignia) masks these layers --}}
+        <div class="lightning-fill-bolt">
+            <div class="lightning-fill-track"></div>
+            @if ($percentage !== null)
+                <div class="lightning-fill-rise"></div>
+            @endif
+        </div>
+
+        {{-- Prior-year benchmark: solid across the bolt (masked, never overhangs),
+             a dashed leader out to the year chip on the right. --}}
+        @if ($showPrior)
+            <div class="lightning-fill-prior-solid" aria-hidden="true"></div>
+            <div class="lightning-fill-prior-leader" aria-hidden="true"></div>
+            @if ($priorYear)
+                <div class="lightning-fill-prior-chip" aria-hidden="true">{{ $priorYear }}</div>
+            @endif
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/admin-settings.blade.php
+++ b/resources/views/livewire/admin-settings.blade.php
@@ -1,0 +1,62 @@
+<div class="max-w-2xl mx-auto">
+    <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+        <h1 class="text-3xl font-bold text-primary">Settings</h1>
+        <label class="flex items-center gap-2" for="admin-settings-year">
+            <span class="text-sm font-medium">Year</span>
+            <select id="admin-settings-year" wire:model.live="selectedYear" class="select select-bordered select-sm w-28">
+                @foreach ($availableYears as $year)
+                    <option value="{{ $year }}">{{ $year }}</option>
+                @endforeach
+            </select>
+        </label>
+    </div>
+
+    <div class="card bg-base-100 shadow-md">
+        <div class="card-body">
+            <h2 class="card-title text-lg">Community goal for {{ $selectedYear }}</h2>
+            <p class="text-sm opacity-70">
+                The annual target for total community sailing days, shown as the
+                lightning fill-up on the public <a href="/stats" class="link link-primary">Community Stats</a> page.
+                Leave blank to unset the goal.
+            </p>
+
+            <form wire:submit="save" class="mt-4 space-y-4">
+                <div>
+                    <label class="label" for="community-goal">
+                        <span class="label-text font-medium">Goal (community sailing days)</span>
+                    </label>
+                    <input type="number"
+                           id="community-goal"
+                           wire:model="goal"
+                           min="1"
+                           max="1000000"
+                           step="1"
+                           placeholder="e.g. 2000"
+                           class="input input-bordered w-full max-w-xs @error('goal') input-error @enderror">
+                    @error('goal')
+                        <p class="text-error text-sm mt-1">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="text-sm opacity-70">
+                    Community total so far in {{ $selectedYear }}:
+                    <span class="font-bold">{{ number_format($currentTotal) }}</span> qualifying days
+                    @if ($goal && $goal > 0)
+                        — <span class="font-bold">{{ (int) round(min(100, $currentTotal / $goal * 100)) }}%</span> of this goal
+                    @endif
+                </div>
+
+                @if ($priorTotal > 0)
+                    <div class="text-sm opacity-70">
+                        For reference, {{ $priorYear }} finished at {{ number_format($priorTotal) }} days @if ($priorIsHistorical)(from the pre-launch process)@endif
+                    </div>
+                @endif
+
+                <button type="submit" class="btn btn-primary" wire:loading.attr="disabled">
+                    <span wire:loading.remove wire:target="save">Save goal</span>
+                    <span wire:loading wire:target="save">Saving…</span>
+                </button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/community-stats.blade.php
+++ b/resources/views/livewire/community-stats.blade.php
@@ -1,0 +1,265 @@
+@php
+    $counters = $stats['counters'];
+    $hasActivity = $counters['activeSailors'] > 0;
+@endphp
+
+<div>
+    {{-- Header. The year selector is intentionally omitted: the app launched in
+         start_year, so there is only ever one selectable year today. Per-metric
+         time framing (all-time / YTD / current) is the planned replacement (#33).
+         The component still resolves selectedYear to the current year internally. --}}
+    <div class="mb-6">
+        <h1 class="text-3xl font-bold text-primary">Community Stats</h1>
+        <p class="text-base-content/70 mt-1">The Lightning community's season, at a glance</p>
+    </div>
+
+    {{-- A. Lightning fill-up hero --}}
+    <div class="card bg-base-100 shadow-md mb-6" wire:key="hero-{{ $selectedYear }}">
+        <div class="card-body items-center text-center">
+            <x-lightning-fill
+                :percentage="$goal ? $goalPercent : null"
+                :prior-percentage="$priorPercent"
+                :goal-label="$goal ? number_format($goal) : null"
+                :prior-year="$priorPercent !== null ? $selectedYear - 1 : null"
+                class="w-48 sm:w-60" />
+            @if ($goal)
+                <p class="text-2xl font-bold mt-2">
+                    {{ number_format($counters['totalQualifying']) }}
+                    <span class="font-normal text-base-content/70">community qualifying days in {{ $selectedYear }}</span>
+                </p>
+                <p class="text-lg {{ $goalPercent >= 100 ? 'text-success font-bold' : 'text-base-content/70' }}">
+                    @if ($goalPercent >= 100)
+                        Goal achieved! ⚡
+                    @else
+                        {{ $goalPercent }}% of the {{ number_format($goal) }}-day {{ $selectedYear }} goal
+                    @endif
+                </p>
+                @if ($priorTotal > 0)
+                    <p class="text-sm text-base-content/60">
+                        {{ $selectedYear - 1 }} finished at {{ number_format($priorTotal) }} days
+                    </p>
+                @endif
+                @if ($goalIsDefault && auth()->check() && auth()->user()->isSuperAdmin())
+                    <p class="text-sm text-base-content/60">
+                        Showing the default {{ number_format($goal) }}-day goal —
+                        <a href="/admin/settings" class="link link-primary">set a {{ $selectedYear }} goal in Settings</a>
+                    </p>
+                @endif
+            @else
+                <p class="text-2xl font-bold mt-2">
+                    {{ number_format($counters['totalQualifying']) }}
+                    <span class="font-normal text-base-content/70">community qualifying days in {{ $selectedYear }}</span>
+                </p>
+            @endif
+        </div>
+    </div>
+
+    {{-- B. Key counters --}}
+    @php
+        $counterTiles = [
+            ['title' => 'Qualifying Days', 'value' => $counters['totalQualifying'], 'desc' => 'Sailing + capped non-sailing'],
+            ['title' => 'Active Sailors', 'value' => $counters['activeSailors'], 'desc' => 'Logged at least one day'],
+            ['title' => 'Active Fleets', 'value' => $counters['activeFleets'], 'desc' => 'Represented on the water'],
+            ['title' => 'Active Districts', 'value' => $counters['activeDistricts'], 'desc' => 'Represented on the water'],
+            ['title' => 'Award Achievers', 'value' => $counters['awardAchievers'], 'desc' => 'Reached 10+ days', 'span' => 'col-span-2 md:col-span-1'],
+        ];
+    @endphp
+    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
+        @foreach ($counterTiles as $i => $tile)
+            <div class="card bg-base-100 shadow-md {{ $tile['span'] ?? '' }}">
+                <div class="stat">
+                    <div class="stat-title">{{ $tile['title'] }}</div>
+                    {{-- Alternating brand blues: primary (dark) / secondary (the homepage "25" blue) --}}
+                    <div class="stat-value text-3xl {{ $i % 2 === 0 ? 'text-primary' : 'text-secondary' }}">{{ number_format($tile['value']) }}</div>
+                    <div class="stat-desc">{{ $tile['desc'] }}</div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    @if ($hasActivity)
+        <div class="space-y-6" wire:loading.class="opacity-50 transition-opacity">
+            {{-- D. Activity heatmap --}}
+            <x-chart-card chart-id="chart-heatmap"
+                          title="When the community sails"
+                          subtitle="Every day of {{ $selectedYear }} — darker means more flashes">
+                @if ($stats['busiestDay'])
+                    <x-slot:caption>
+                        Busiest day:
+                        <span class="font-semibold text-base-content">{{ $stats['busiestDay']['date'] }}</span>
+                        — {{ $stats['busiestDay']['sailors'] }} sailors on the water
+                    </x-slot:caption>
+                @endif
+                <x-slot:table>
+                    <table class="table table-xs">
+                        <thead><tr><th>Date</th><th class="text-right">Flashes</th></tr></thead>
+                        <tbody>
+                            @foreach ($stats['heatmap'] as $day => $count)
+                                <tr><td>{{ $day }}</td><td class="text-right">{{ $count }}</td></tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </x-slot:table>
+            </x-chart-card>
+
+            {{-- Flashes over the season — interactive running total. Leads the
+                 activity block: it extends the hero's qualifying-days thread.
+                 Table twin: flashes per month × activity type (the chart is
+                 filterable, so the twin gives the full aggregate). --}}
+            <x-chart-card chart-id="chart-flash-filter"
+                          title="Flashes over the season"
+                          subtitle="Running total of every flash in {{ $selectedYear }} — toggle activity types, genders, age groups, or count vs share">
+                <x-slot:table>
+                    @php
+                        $monthNames = ['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+                        $cats = $stats['flashFilter']['categories'];
+                        $matrix = $monthTotals = $catTotals = [];
+                        foreach ($stats['flashFilter']['rows'] as $r) {
+                            $m = (int) substr($r['date'], 5, 2);
+                            $matrix[$m][$r['category']] = ($matrix[$m][$r['category']] ?? 0) + $r['count'];
+                            $monthTotals[$m] = ($monthTotals[$m] ?? 0) + $r['count'];
+                            $catTotals[$r['category']] = ($catTotals[$r['category']] ?? 0) + $r['count'];
+                        }
+                        $activeMonths = array_filter(range(1, 12), fn ($m) => ($monthTotals[$m] ?? 0) > 0);
+                    @endphp
+                    <table class="table table-xs">
+                        <thead>
+                            <tr>
+                                <th>Month</th>
+                                @foreach ($cats as $cat)
+                                    <th class="text-right">{{ $cat['label'] }}</th>
+                                @endforeach
+                                <th class="text-right">Total</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($activeMonths as $m)
+                                <tr>
+                                    <td>{{ $monthNames[$m] }}</td>
+                                    @foreach ($cats as $cat)
+                                        <td class="text-right">{{ $matrix[$m][$cat['key']] ?? 0 }}</td>
+                                    @endforeach
+                                    <td class="text-right">{{ $monthTotals[$m] }}</td>
+                                </tr>
+                            @endforeach
+                            <tr class="font-semibold">
+                                <td>Total</td>
+                                @foreach ($cats as $cat)
+                                    <td class="text-right">{{ $catTotals[$cat['key']] ?? 0 }}</td>
+                                @endforeach
+                                <td class="text-right">{{ array_sum($catTotals) }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </x-slot:table>
+            </x-chart-card>
+
+            {{-- Community growth — cumulative sailors, stackable (defaults to age) --}}
+            <x-chart-card chart-id="chart-cumulative"
+                          title="Community growth"
+                          subtitle="Running total of registered sailors through {{ $selectedYear }} — stack by age or gender, count or share">
+                <x-slot:table>
+                    <table class="table table-xs">
+                        <thead><tr><th>Date</th><th class="text-right">Total sailors</th></tr></thead>
+                        <tbody>
+                            @foreach ($stats['sailorGrowth']['totals'] as $point)
+                                <tr><td>{{ $point['date'] }}</td><td class="text-right">{{ $point['total'] }}</td></tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </x-slot:table>
+            </x-chart-card>
+
+            {{-- Sailor ages + award funnel — compact pair. items-start so expanding
+                 one card's data table doesn't push its grid neighbor down. --}}
+            <div class="grid md:grid-cols-2 gap-6 items-start stats-duo">
+                {{-- G. Age distribution --}}
+                <x-chart-card chart-id="chart-ages"
+                              title="Sailor ages"
+                              subtitle="Active sailors in {{ $selectedYear }}, by Lightning Class age division and gender">
+                    <x-slot:table>
+                        <table class="table table-xs">
+                            <thead>
+                                <tr>
+                                    <th>Division</th>
+                                    <th>Ages</th>
+                                    @foreach ($stats['ages']['genders'] as $g)
+                                        <th class="text-right">{{ $g['label'] }}</th>
+                                    @endforeach
+                                    <th class="text-right">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($stats['ages']['labels'] as $i => $label)
+                                    @php $row = $stats['ages']['counts'][$label] ?? []; @endphp
+                                    <tr>
+                                        <td>{{ $label }}</td>
+                                        <td class="opacity-70">{{ $stats['ages']['ranges'][$i] }}</td>
+                                        @foreach ($stats['ages']['genders'] as $g)
+                                            <td class="text-right">{{ $row[$g['key']] ?? 0 }}</td>
+                                        @endforeach
+                                        <td class="text-right">{{ array_sum($row) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </x-slot:table>
+                </x-chart-card>
+
+                {{-- H. Award tier funnel --}}
+                <x-chart-card chart-id="chart-funnel"
+                              title="From sign-up to award"
+                              subtitle="How far {{ $selectedYear }} sailors climb — registered, active, then each award">
+                    <x-slot:table>
+                        <table class="table table-xs">
+                            <thead><tr><th>Stage</th><th class="text-right">Sailors</th><th class="text-right">% of registered</th></tr></thead>
+                            <tbody>
+                                @php $registered = $stats['funnel'][0]['count'] ?? 0; @endphp
+                                @foreach ($stats['funnel'] as $stage)
+                                    <tr>
+                                        <td>{{ $stage['label'] }}</td>
+                                        <td class="text-right">{{ $stage['count'] }}</td>
+                                        <td class="text-right opacity-70">{{ $registered ? round($stage['count'] / $registered * 100) : 0 }}%</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </x-slot:table>
+                </x-chart-card>
+            </div>
+
+            {{-- J. Fun facts --}}
+            @if (count($stats['funFacts']) > 0)
+                <div>
+                    <h2 class="text-xl font-bold mb-4">Fun facts</h2>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                        @foreach ($stats['funFacts'] as $fact)
+                            <div class="card bg-base-100 shadow-md">
+                                <div class="card-body py-4">
+                                    <div class="text-sm text-base-content/60">{{ $fact['title'] }}</div>
+                                    <div class="text-xl font-bold text-primary">{{ $fact['value'] }}</div>
+                                    <div class="text-sm text-base-content/70">{{ $fact['detail'] }}</div>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+        </div>
+    @else
+        {{-- Empty state: no activity for this year --}}
+        <div class="card bg-base-100 shadow-md">
+            <div class="card-body items-center text-center py-16">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                <h2 class="text-xl font-bold mt-4">No activity logged for {{ $selectedYear }} yet</h2>
+                <p class="text-base-content/70">Check back once sailors start logging their days on the water.</p>
+            </div>
+        </div>
+    @endif
+
+    {{-- Chart data for stats-charts.js (initial load; year changes arrive via the
+         community-stats-updated browser event) --}}
+    <script type="application/json" id="community-stats-data">{!! $chartJson !!}</script>
+</div>

--- a/resources/views/stats/index.blade.php
+++ b/resources/views/stats/index.blade.php
@@ -1,0 +1,6 @@
+<x-layout>
+    <x-slot:title>Community Stats</x-slot:title>
+    <x-slot:description>See the Lightning Class community's sailing season at a glance: progress toward the annual community goal, activity trends, and fun facts from the G.O.T. Flashes challenge.</x-slot:description>
+
+    @livewire('community-stats')
+</x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,10 @@ Route::get('/sitemap.xml', SitemapController::class);
 Route::get('/leaderboard', [LeaderboardController::class, 'index'])
     ->name('leaderboard');
 
+// Public community statistics page
+Route::view('/stats', 'stats.index')
+    ->name('stats');
+
 // API routes for fleets and districts
 // Cache for 1 hour, then revalidate with ETag (balances freshness and performance)
 // No rate limiting needed - these are lightweight read-only endpoints with browser caching
@@ -89,10 +93,15 @@ Route::post('/password/reset', ResetPassword::class)
 Route::get('/verify-email/{token}', VerifyEmailChangeController::class)
     ->name('verify-email-change');
 
-// Admin routes
+// Admin routes (award administration)
 Route::middleware(['auth', 'admin'])->prefix('admin')->group(function () {
     Route::view('/fulfillment', 'admin.awards-dashboard')->name('admin.fulfillment');
     Route::view('/sailor-logs', 'admin.sailor-logs')->name('admin.sailor-logs');
+});
+
+// Site-operator routes (elevated tier) — site configuration
+Route::middleware(['auth', 'super_admin'])->prefix('admin')->group(function () {
+    Route::view('/settings', 'admin.settings')->name('admin.settings');
 });
 
 // Fallback route for 404 errors - must be last

--- a/tests/Feature/AdminSettingsTest.php
+++ b/tests/Feature/AdminSettingsTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Flash;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AdminSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->travelTo('2026-06-15');
+    }
+
+    public function test_guests_are_redirected_to_login(): void
+    {
+        $this->get('/admin/settings')->assertRedirect('/login');
+    }
+
+    public function test_non_admins_get_403(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user)->get('/admin/settings')->assertStatus(403);
+    }
+
+    public function test_award_admins_without_super_admin_get_403(): void
+    {
+        // Award administration (is_admin) is not enough for site settings —
+        // the settings page requires the elevated site-operator tier.
+        $awardAdmin = User::factory()->create(['is_admin' => true, 'is_super_admin' => false]);
+
+        $this->actingAs($awardAdmin)->get('/admin/settings')->assertStatus(403);
+    }
+
+    public function test_admins_can_view_settings_page(): void
+    {
+        $admin = User::factory()->create(['is_super_admin' => true]);
+
+        $response = $this->actingAs($admin)->get('/admin/settings');
+
+        $response->assertStatus(200);
+        $response->assertSee('Community goal for 2026');
+    }
+
+    public function test_admin_can_save_goal(): void
+    {
+        $admin = User::factory()->create(['is_super_admin' => true]);
+
+        Livewire::actingAs($admin)
+            ->test('admin-settings')
+            ->set('goal', 2000)
+            ->call('save')
+            ->assertHasNoErrors()
+            ->assertDispatched('toast');
+
+        $this->assertSame('2000', Setting::get('community_goal_2026'));
+    }
+
+    public function test_saving_goal_clears_stats_cache_for_that_year(): void
+    {
+        $admin = User::factory()->create(['is_super_admin' => true]);
+        // Matches CommunityStats::cacheKey() (versioned)
+        Cache::put('community-stats-v13-2026', ['stale' => true], 900);
+
+        Livewire::actingAs($admin)
+            ->test('admin-settings')
+            ->set('goal', 500)
+            ->call('save');
+
+        $this->assertNull(Cache::get('community-stats-v13-2026'));
+    }
+
+    public function test_goal_validation_rejects_non_positive_values(): void
+    {
+        $admin = User::factory()->create(['is_super_admin' => true]);
+
+        Livewire::actingAs($admin)
+            ->test('admin-settings')
+            ->set('goal', 0)
+            ->call('save')
+            ->assertHasErrors(['goal']);
+    }
+
+    public function test_goal_can_be_cleared(): void
+    {
+        Setting::set('community_goal_2026', '1000');
+        $admin = User::factory()->create(['is_super_admin' => true]);
+
+        Livewire::actingAs($admin)
+            ->test('admin-settings')
+            ->set('goal', null)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertNull(Setting::get('community_goal_2026'));
+    }
+
+    public function test_goal_loads_for_selected_year(): void
+    {
+        Setting::set('community_goal_2026', '1500');
+        Setting::set('community_goal_2025', '800');
+        $admin = User::factory()->create(['is_super_admin' => true]);
+        Flash::factory()->forUser($admin)->sailing()->onDate('2025-05-01')->create();
+
+        Livewire::actingAs($admin)
+            ->test('admin-settings')
+            ->assertSet('goal', 1500)
+            ->set('selectedYear', 2025)
+            ->assertSet('goal', 800);
+    }
+
+    public function test_shows_progress_toward_goal(): void
+    {
+        $admin = User::factory()->create(['is_super_admin' => true]);
+        Flash::factory()->forUser($admin)->sailing()->onDate('2026-05-01')->create();
+        Setting::set('community_goal_2026', '100');
+
+        Livewire::actingAs($admin)
+            ->test('admin-settings')
+            ->assertSee('1%');
+    }
+
+    public function test_shows_prior_year_historical_reference(): void
+    {
+        $admin = User::factory()->create(['is_super_admin' => true]);
+        $expected = number_format((int) config('community.historical_totals')[2025]);
+
+        Livewire::actingAs($admin)
+            ->test('admin-settings')
+            ->assertSee("2025 finished at {$expected} days")
+            ->assertSee('pre-launch process');
+    }
+
+    public function test_available_years_excludes_pre_launch_years(): void
+    {
+        $admin = User::factory()->create(['is_super_admin' => true]);
+
+        // A flash dated before START_YEAR (2026) must not become a selectable year:
+        // the public stats page floors at the launch year, and getQualifyingTotal()
+        // would silently report 0 for such a year.
+        Flash::factory()->forUser($admin)->sailing()->onDate('2025-07-01')->create();
+        Flash::factory()->forUser($admin)->sailing()->onDate('2026-07-01')->create();
+
+        $years = Livewire::actingAs($admin)
+            ->test('admin-settings')
+            ->viewData('availableYears');
+
+        $this->assertContains(2026, $years);
+        $this->assertNotContains(2025, $years);
+    }
+}

--- a/tests/Feature/CommunityStatsTest.php
+++ b/tests/Feature/CommunityStatsTest.php
@@ -1,0 +1,486 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\District;
+use App\Models\Flash;
+use App\Models\Fleet;
+use App\Models\Member;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CommunityStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->travelTo('2026-06-15');
+    }
+
+    public function test_stats_page_loads_for_guests(): void
+    {
+        $response = $this->get('/stats');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('stats.index');
+        $response->assertSee('Community Stats');
+    }
+
+    public function test_stats_page_shows_key_counters(): void
+    {
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-02')->create();
+
+        $component = Livewire::test('community-stats');
+        $counters = $component->viewData('stats')['counters'];
+
+        $this->assertSame(2, $counters['totalQualifying']);
+        $this->assertSame(1, $counters['activeSailors']);
+        $this->assertSame(0, $counters['awardAchievers']);
+    }
+
+    public function test_non_sailing_days_are_capped_at_five_in_qualifying_total(): void
+    {
+        $user = User::factory()->create();
+
+        foreach (range(1, 3) as $day) {
+            Flash::factory()->forUser($user)->sailing()->onDate("2026-05-0{$day}")->create();
+        }
+        foreach (range(10, 17) as $day) {
+            Flash::factory()->forUser($user)->maintenance()->onDate("2026-05-{$day}")->create();
+        }
+
+        $counters = Livewire::test('community-stats')->viewData('stats')['counters'];
+
+        // 3 sailing + 8 non-sailing capped at 5 = 8
+        $this->assertSame(8, $counters['totalQualifying']);
+    }
+
+    public function test_award_achievers_counts_sailors_with_ten_plus_qualifying_days(): void
+    {
+        $achiever = User::factory()->create();
+        foreach (range(1, 12) as $day) {
+            $date = sprintf('2026-05-%02d', $day);
+            Flash::factory()->forUser($achiever)->sailing()->onDate($date)->create();
+        }
+
+        $casual = User::factory()->create();
+        Flash::factory()->forUser($casual)->sailing()->onDate('2026-05-01')->create();
+
+        $counters = Livewire::test('community-stats')->viewData('stats')['counters'];
+
+        $this->assertSame(1, $counters['awardAchievers']);
+        $this->assertSame(2, $counters['activeSailors']);
+    }
+
+    public function test_active_fleets_and_districts_counted_via_membership(): void
+    {
+        $fleet = Fleet::query()->firstOrFail();
+
+        $user = User::factory()->create();
+        Member::create([
+            'user_id' => $user->id,
+            'district_id' => $fleet->district_id,
+            'fleet_id' => $fleet->id,
+            'year' => 2026,
+        ]);
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+
+        $counters = Livewire::test('community-stats')->viewData('stats')['counters'];
+
+        $this->assertSame(1, $counters['activeFleets']);
+        $this->assertSame(1, $counters['activeDistricts']);
+    }
+
+    public function test_sentinel_none_fleet_and_district_are_not_counted_as_active(): void
+    {
+        $noneFleetId = Fleet::noneId();
+        $noneDistrictId = District::noneId();
+
+        $user = User::factory()->create();
+        Member::create([
+            'user_id' => $user->id,
+            'district_id' => $noneDistrictId,
+            'fleet_id' => $noneFleetId,
+            'year' => 2026,
+        ]);
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+
+        $counters = Livewire::test('community-stats')->viewData('stats')['counters'];
+
+        $this->assertSame(0, $counters['activeFleets']);
+        $this->assertSame(0, $counters['activeDistricts']);
+        $this->assertSame(1, $counters['activeSailors']);
+    }
+
+    public function test_flash_filter_data_breaks_down_by_dimensions(): void
+    {
+        $male = User::factory()->create(['gender' => 'male', 'date_of_birth' => '2000-01-01']); // U32 in 2026
+        Flash::factory()->forUser($male)->sailing()->onDate('2026-05-01')->create(['event_type' => 'regatta']);
+
+        $female = User::factory()->create(['gender' => 'female', 'date_of_birth' => '1960-01-01']); // Masters
+        Flash::factory()->forUser($female)->maintenance()->onDate('2026-05-01')->create();
+
+        $filter = Livewire::test('community-stats')->viewData('stats')['flashFilter'];
+
+        $this->assertContains('male', array_column($filter['genders'], 'key'));
+        $this->assertContains('female', array_column($filter['genders'], 'key'));
+        $this->assertContains('u32', array_column($filter['ageGroups'], 'key'));
+        $this->assertContains('masters', array_column($filter['ageGroups'], 'key'));
+
+        $row = collect($filter['rows'])->firstWhere(fn ($r) => $r['category'] === 'regatta');
+        $this->assertSame('male', $row['gender']);
+        $this->assertSame('u32', $row['ageGroup']);
+        $this->assertSame(1, $row['count']);
+    }
+
+    public function test_sailor_growth_totals_are_a_running_total_by_date(): void
+    {
+        User::factory()->create(['created_at' => '2026-02-05 10:00:00', 'gender' => 'male', 'date_of_birth' => '2000-01-01']);
+        User::factory()->create(['created_at' => '2026-02-05 12:00:00', 'gender' => 'female', 'date_of_birth' => '1960-01-01']);
+        User::factory()->create(['created_at' => '2026-04-10 09:00:00', 'gender' => 'male', 'date_of_birth' => '2000-01-01']);
+
+        $growth = Livewire::test('community-stats')->viewData('stats')['sailorGrowth'];
+        $byDate = collect($growth['totals'])->keyBy('date');
+
+        $this->assertSame(2, $byDate['2026-02-05']['total']);
+        $this->assertSame(3, $byDate['2026-04-10']['total']);
+
+        // Broken down for stacking by gender and age
+        $this->assertContains('male', array_column($growth['genders'], 'key'));
+        $this->assertContains('female', array_column($growth['genders'], 'key'));
+        $this->assertContains('u32', array_column($growth['ageGroups'], 'key'));
+        $this->assertContains('masters', array_column($growth['ageGroups'], 'key'));
+        $feb5Male = collect($growth['rows'])->first(fn ($r) => $r['date'] === '2026-02-05' && $r['gender'] === 'male');
+        $this->assertSame('u32', $feb5Male['ageGroup']);
+        $this->assertSame(1, $feb5Male['count']);
+    }
+
+    public function test_heatmap_contains_flash_counts_per_day(): void
+    {
+        $userOne = User::factory()->create();
+        $userTwo = User::factory()->create();
+        Flash::factory()->forUser($userOne)->sailing()->onDate('2026-05-01')->create();
+        Flash::factory()->forUser($userTwo)->sailing()->onDate('2026-05-01')->create();
+
+        $stats = Livewire::test('community-stats')->viewData('stats');
+
+        $this->assertSame(2, $stats['heatmap']['2026-05-01']);
+    }
+
+    public function test_age_distribution_redistributes_implausible_ages(): void
+    {
+        // Babies are legitimately brought aboard, so there is no lower age floor;
+        // only a missing DOB or an implausible age (an absurd birth year from bad
+        // data) reads as unknown. Unknown ages are redistributed into the displayed
+        // divisions proportionally, so there is no Unknown bucket and everyone is
+        // counted. Here the only disclosed division is 33–54, so the lone bad-data
+        // sailor lands there rather than inflating Youth or surfacing as Unknown.
+        $sailor = User::factory()->create(['date_of_birth' => '1990-06-01', 'gender' => 'male']); // 36 in 2026 → 33–54
+        $implausible = User::factory()->create(['date_of_birth' => '1900-01-02', 'gender' => 'male']); // age > 100 → unknown
+        Flash::factory()->forUser($sailor)->sailing()->onDate('2026-05-01')->create();
+        Flash::factory()->forUser($implausible)->sailing()->onDate('2026-05-02')->create();
+
+        $ages = Livewire::test('community-stats')->viewData('stats')['ages'];
+
+        $total = array_sum(array_map('array_sum', $ages['counts']));
+        $this->assertSame(2, $total); // both counted
+        $this->assertNotContains('Unknown', $ages['labels']); // no Unknown bucket
+        $this->assertSame(2, $ages['counts']['33–54']['male']); // bad-data sailor redistributed here
+    }
+
+    public function test_age_distribution_counts_young_children_as_youth(): void
+    {
+        // A genuine young child (age 3) counts as Youth, not Unknown.
+        $child = User::factory()->create(['date_of_birth' => '2023-06-01', 'gender' => 'female']);
+        Flash::factory()->forUser($child)->sailing()->onDate('2026-05-01')->create();
+
+        $ages = Livewire::test('community-stats')->viewData('stats')['ages'];
+
+        $this->assertSame(1, $ages['counts']['Youth']['female']);
+        $this->assertNotContains('Unknown', $ages['labels']);
+    }
+
+    public function test_age_distribution_buckets_by_class_division(): void
+    {
+        // One sailor per division; "Open" is intentionally gone (a misnomer for age).
+        $birthYears = ['Youth' => 2011, 'U32' => 2000, '33–54' => 1985, 'Masters' => 1960];
+        foreach ($birthYears as $birthYear) {
+            $u = User::factory()->create(['date_of_birth' => "{$birthYear}-06-01", 'gender' => 'female']);
+            Flash::factory()->forUser($u)->sailing()->onDate('2026-05-01')->create();
+        }
+
+        $dist = Livewire::test('community-stats')->viewData('stats')['ages'];
+
+        $this->assertSame(['Youth', 'U32', '33–54', 'Masters'], $dist['labels']);
+        $this->assertNotContains('Open', $dist['labels']);
+        foreach (['Youth', 'U32', '33–54', 'Masters'] as $division) {
+            $this->assertSame(1, $dist['counts'][$division]['female'], "{$division} bucket");
+        }
+    }
+
+    public function test_age_distribution_redistributes_undisclosed_gender(): void
+    {
+        $female = User::factory()->create(['date_of_birth' => '2000-06-01', 'gender' => 'female']);
+        $male = User::factory()->create(['date_of_birth' => '2000-06-01', 'gender' => 'male']);
+        $undisclosed = User::factory()->create(['date_of_birth' => '2000-06-01', 'gender' => 'prefer_not_to_say']);
+        foreach ([$female, $male, $undisclosed] as $u) {
+            Flash::factory()->forUser($u)->sailing()->onDate('2026-05-01')->create();
+        }
+
+        $dist = Livewire::test('community-stats')->viewData('stats')['ages'];
+
+        $genderKeys = array_column($dist['genders'], 'key');
+        $this->assertContains('female', $genderKeys);
+        $this->assertContains('male', $genderKeys);
+        // "prefer not to say" carries no series — it is redistributed into the shown
+        // genders (not dropped), so all three sailors are still counted in U32.
+        $this->assertNotContains('prefer_not_to_say', $genderKeys);
+        $this->assertArrayNotHasKey('prefer_not_to_say', $dist['counts']['U32']);
+        $this->assertSame(3, $dist['counts']['U32']['male'] + $dist['counts']['U32']['female']);
+    }
+
+    public function test_age_distribution_surfaces_undisclosed_when_no_disclosed_gender(): void
+    {
+        // Degenerate year: every active sailor is undisclosed, so there is no
+        // disclosed group to redistribute into. The chart must still show them
+        // rather than silently rendering zero everywhere.
+        foreach (['2000-06-01', '1985-06-01'] as $dob) {
+            $u = User::factory()->create(['date_of_birth' => $dob, 'gender' => 'prefer_not_to_say']);
+            Flash::factory()->forUser($u)->sailing()->onDate('2026-05-01')->create();
+        }
+
+        $dist = Livewire::test('community-stats')->viewData('stats')['ages'];
+
+        $total = array_sum(array_map('array_sum', $dist['counts']));
+        $this->assertSame(2, $total); // both counted, not dropped
+        $this->assertContains('prefer_not_to_say', array_column($dist['genders'], 'key'));
+    }
+
+    public function test_award_funnel_is_cumulative_registered_to_tiers(): void
+    {
+        // 3 registered: one never logs, one logs 1 day, one reaches 10+ days
+        User::factory()->create(); // never logged
+
+        $starter = User::factory()->create();
+        Flash::factory()->forUser($starter)->sailing()->onDate('2026-05-01')->create();
+
+        $achiever = User::factory()->create();
+        foreach (range(1, 11) as $day) {
+            Flash::factory()->forUser($achiever)->sailing()->onDate(sprintf('2026-04-%02d', $day))->create();
+        }
+
+        $funnel = Livewire::test('community-stats')->viewData('stats')['funnel'];
+
+        $this->assertSame('Registered', $funnel[0]['label']);
+        $this->assertSame(3, $funnel[0]['count']);  // all registered
+        $this->assertSame(2, $funnel[1]['count']);  // logged a day (active)
+        $this->assertSame(1, $funnel[2]['count']);  // reached 10+
+        $this->assertSame(0, $funnel[3]['count']);  // reached 25+
+        $this->assertSame(0, $funnel[4]['count']);  // reached 50+
+    }
+
+    public function test_goal_display_with_goal_set(): void
+    {
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+        Setting::set('community_goal_2026', '100');
+
+        Livewire::test('community-stats')
+            ->assertSee('100')
+            ->assertSee('1% of the 100-day 2026 goal');
+    }
+
+    public function test_prior_year_benchmark_uses_hardcoded_historical_total(): void
+    {
+        // The app launched in 2026, so the 2025 benchmark comes from the
+        // hardcoded pre-launch aggregate (config/community.php), NOT the DB.
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+        Setting::set('community_goal_2026', '2000');
+
+        $expected = number_format((int) config('community.historical_totals')[2025]);
+
+        Livewire::test('community-stats')
+            ->assertSet('selectedYear', 2026)
+            ->assertSee("2025 finished at {$expected} days");
+    }
+
+    public function test_prelaunch_years_are_not_selectable(): void
+    {
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+        // Even if pre-launch rows somehow exist, they must not be offered.
+        Flash::factory()->forUser($user)->sailing()->onDate('2025-05-01')->create();
+
+        $years = Livewire::test('community-stats')->viewData('availableYears');
+
+        $this->assertContains(2026, $years);
+        $this->assertNotContains(2025, $years);
+    }
+
+    public function test_goal_achieved_state(): void
+    {
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-02')->create();
+        Setting::set('community_goal_2026', '2');
+
+        Livewire::test('community-stats')
+            ->assertSee('Goal achieved!');
+    }
+
+    public function test_super_admins_see_default_goal_hint_when_no_explicit_goal(): void
+    {
+        // With no year-specific goal set, the page uses the config default and
+        // nudges a site admin to set one; award-admins don't get the nudge.
+        $siteAdmin = User::factory()->create(['is_super_admin' => true]);
+        Flash::factory()->forUser($siteAdmin)->sailing()->onDate('2026-05-01')->create();
+
+        Livewire::actingAs($siteAdmin)
+            ->test('community-stats')
+            ->assertSee('Showing the default')
+            ->assertSee('set a 2026 goal in Settings');
+    }
+
+    public function test_award_admins_do_not_see_default_goal_hint(): void
+    {
+        $awardAdmin = User::factory()->create(['is_admin' => true, 'is_super_admin' => false]);
+        Flash::factory()->forUser($awardAdmin)->sailing()->onDate('2026-05-01')->create();
+
+        Livewire::actingAs($awardAdmin)
+            ->test('community-stats')
+            ->assertDontSee('Showing the default');
+    }
+
+    public function test_guests_do_not_see_default_goal_hint(): void
+    {
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+
+        Livewire::test('community-stats')
+            ->assertDontSee('Showing the default');
+    }
+
+    public function test_year_change_dispatches_chart_update_event(): void
+    {
+        // Switch between two post-launch years (2025 is pre-launch, unselectable)
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2027-05-01')->create();
+
+        Livewire::test('community-stats')
+            ->set('selectedYear', 2027)
+            ->assertSet('selectedYear', 2027)
+            ->assertDispatched('community-stats-updated');
+    }
+
+    public function test_invalid_year_falls_back_to_current_year(): void
+    {
+        Livewire::withQueryParams(['selectedYear' => 1999])
+            ->test('community-stats')
+            ->assertSet('selectedYear', 2026);
+    }
+
+    public function test_empty_year_shows_empty_state(): void
+    {
+        Livewire::test('community-stats')
+            ->assertSee('No activity logged for 2026 yet');
+    }
+
+    public function test_busiest_day_shown_in_heatmap_caption(): void
+    {
+        $userOne = User::factory()->create();
+        $userTwo = User::factory()->create();
+        Flash::factory()->forUser($userOne)->sailing()->onDate('2026-05-16')->create();
+        Flash::factory()->forUser($userTwo)->sailing()->onDate('2026-05-16')->create();
+
+        Livewire::test('community-stats')
+            ->assertSee('Busiest day')
+            ->assertSee('May 16')
+            ->assertSee('2 sailors on the water');
+    }
+
+    public function test_fun_facts_include_season_opener(): void
+    {
+        $early = User::factory()->create(['first_name' => 'Ada', 'last_name' => 'Early']);
+        $late = User::factory()->create();
+        Flash::factory()->forUser($early)->sailing()->onDate('2026-03-05')->create();
+        Flash::factory()->forUser($late)->sailing()->onDate('2026-06-10')->create();
+
+        Livewire::test('community-stats')
+            ->assertSee('Season opener')
+            ->assertSee('March 5')
+            ->assertSee('Ada Early');
+    }
+
+    public function test_fun_facts_include_longest_sailing_streak(): void
+    {
+        $user = User::factory()->create(['first_name' => 'Streaky', 'last_name' => 'Sam']);
+        foreach (['2026-06-01', '2026-06-02', '2026-06-03', '2026-06-04'] as $date) {
+            Flash::factory()->forUser($user)->sailing()->onDate($date)->create();
+        }
+
+        Livewire::test('community-stats')
+            ->assertSee('Longest sailing streak')
+            ->assertSee('Streaky Sam sailed 4 days in a row');
+    }
+
+    public function test_longest_streak_credits_all_tied_sailors(): void
+    {
+        $ann = User::factory()->create(['first_name' => 'Ann', 'last_name' => 'Aye']);
+        $ben = User::factory()->create(['first_name' => 'Ben', 'last_name' => 'Bee']);
+        foreach (['2026-06-01', '2026-06-02', '2026-06-03'] as $date) {
+            Flash::factory()->forUser($ann)->sailing()->onDate($date)->create();
+            Flash::factory()->forUser($ben)->sailing()->onDate($date)->create();
+        }
+
+        Livewire::test('community-stats')
+            ->assertSee('Ann Aye and Ben Bee each sailed 3 days in a row');
+    }
+
+    public function test_fun_facts_omit_free_text_location(): void
+    {
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create(['location' => 'Pymatuning']);
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-02')->create(['location' => 'Pymatuning']);
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-03')->create(['location' => 'Pymatuning']);
+
+        Livewire::test('community-stats')
+            ->assertDontSee('Most popular location');
+    }
+
+    public function test_fun_facts_include_most_flashes_logged_at_once(): void
+    {
+        $user = User::factory()->create();
+        $bulk = now()->setDate(2026, 3, 21)->setTime(18, 26, 23);
+
+        // Four flashes created in a single entry (shared created_at)
+        foreach (['2026-05-01', '2026-05-02', '2026-05-03', '2026-05-04'] as $date) {
+            Flash::factory()->forUser($user)->sailing()->onDate($date)->create([
+                'created_at' => $bulk,
+                'updated_at' => $bulk,
+            ]);
+        }
+
+        Livewire::test('community-stats')
+            ->assertSee('Most flashes logged at once')
+            ->assertSee('4 flashes');
+    }
+
+    public function test_chart_json_payload_is_embedded(): void
+    {
+        $user = User::factory()->create();
+        Flash::factory()->forUser($user)->sailing()->onDate('2026-05-01')->create();
+
+        $this->get('/stats')
+            ->assertSee('community-stats-data', false)
+            ->assertSee('"monthsToShow"', false);
+    }
+}


### PR DESCRIPTION
Single squash-merged PR from `develop` (#59, issue #33). Ships the public community statistics page and a new site-operator role. The two migrations below self-apply in production within one poll cycle of the `:latest` republish.

## Added
- **Public community stats page at `/stats`** (#59). A "lightning goal fill-up" hero animates toward a configurable community sailing goal, backed by five D3 charts (activity heatmap, flashes over the season, community growth, sailor ages, award funnel), key counters, and fun facts. Every chart has a server-rendered `<details>` data-table twin for accessibility and no-hover value access.
- **`super_admin` site-operator role** (`is_super_admin`) gating a new `/admin/settings` page where a site operator sets the per-year community goal. A distinct, elevated tier above the award-admin role (`is_admin`).
- **`settings` key-value table + `Setting` model** for persisted site settings (per-year community goal, keyed `community_goal_{year}`).

## Changed
- Undisclosed-gender and unknown-age sailors are redistributed into the displayed demographic groups on the stats charts rather than shown as a separate catch-all slice.
- Default community goal set to 2500; the 2025 benchmark is 1550 raw sailor-days.

## Technical
- `CommunityStats` Livewire component aggregates per year behind a 15-min cache (`community-stats-{year}`), reusing the leaderboard's capped-qualifying-count + membership carry-forward SQL and excluding the sentinel None fleet/district from group counts.
- Charts stay CSP-safe (no `unsafe-eval`): D3 reads a JSON script tag plus the `community-stats-updated` browser event; the fill-up hero is a pure CSS clip-path keyframe animation (no Alpine). Chart containers sit in `wire:ignore`.
- `AdminSettings` Livewire component clears the affected year's stats cache on save.

## Migrations (self-apply on deploy)
- `create_settings_table` — new `settings` key-value table.
- `add_is_super_admin_to_users` — `is_super_admin` boolean column (default false).

## Deploy note
On merge + CI republish of `:latest`, the production poller applies both migrations automatically within one 5-minute poll cycle. No manual step; covered by the 02:00 daily backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
